### PR TITLE
[fix #279] export button in publication menu

### DIFF
--- a/src/main/storage/publication-storage.ts
+++ b/src/main/storage/publication-storage.ts
@@ -21,6 +21,8 @@ import { PublicationView } from "readium-desktop/common/views/publication";
 
 import slugify from "slugify";
 
+import { dialog } from "electron";
+
 // Store publications in a repository on filesystem
 // Each file of publication is stored in a directory whose name is the
 // publication uuid
@@ -85,7 +87,16 @@ export class PublicationStorage {
     public copyPublicationToPath(publication: PublicationView, destinationPath: string) {
         const publicationPath = `${this.buildPublicationPath(publication.identifier)}/book.epub`;
         const newFilePath = `${destinationPath}/${slugify(publication.title)}.epub`;
-        fs.copyFileSync(publicationPath, newFilePath);
+        fs.copyFile(publicationPath, newFilePath, (err) => {
+            if (err) {
+                dialog.showMessageBox({
+                    type: "error",
+                    message: err.message,
+                    title: err.name,
+                    buttons: ["OK"],
+                });
+            }
+        });
     }
 
     private buildPublicationPath(identifier: string): string {
@@ -105,7 +116,7 @@ export class PublicationStorage {
         return new Promise<File>((resolve, reject) => {
             const writeStream = fs.createWriteStream(dstPath);
             const fileResolve = () => {
-                resolve ({
+                resolve({
                     url: `store://${identifier}/${filename}`,
                     ext: "epub",
                     contentType: "application/epub+zip",

--- a/src/renderer/components/publication/menu/PublicationExportButton.tsx
+++ b/src/renderer/components/publication/menu/PublicationExportButton.tsx
@@ -28,11 +28,7 @@ class PublicationExportButton extends React.Component<PublicationCardProps> {
         this.state = {
             menuOpen: false,
         };
-
         this.exportInputRef = React.createRef();
-
-        this.onExport = this.onExport.bind(this);
-        this.onClick = this.onClick.bind(this);
     }
 
     public componentDidMount() {
@@ -50,8 +46,7 @@ class PublicationExportButton extends React.Component<PublicationCardProps> {
                         ref={ this.exportInputRef }
                         type="file"
                         multiple
-                        onChange={this.onExport}
-                        onClick={ this.onClick }
+                        onChange={ this.onExport }
                     />
                     <label htmlFor={ id }>
                         { __("catalog.export")}
@@ -60,11 +55,8 @@ class PublicationExportButton extends React.Component<PublicationCardProps> {
         );
     }
 
-    private onClick(e: any) {
+    private onExport = (event: React.ChangeEvent<HTMLInputElement>) => {
         this.props.onClick();
-    }
-
-    private onExport(event: any) {
         const destinationPath = event.target.files[0].path;
         const publication = this.props.publication;
         this.props.exportPublication({ destinationPath, publication });


### PR DESCRIPTION
- I removed onClick on component
- On API publication-storage : I changed copyFileSync to async version and I added a messageBox on error

test on ubuntu lts 18 and not mac-os/win

fixed: #279 