### PR TITLE
WIP: fixes the left/right arrow keyboard events the reader view

### DIFF
--- a/src/renderer/components/dialog/DialogManager.tsx
+++ b/src/renderer/components/dialog/DialogManager.tsx
@@ -228,6 +228,11 @@ export class DialogManager extends React.Component<DialogManagerProps, undefined
 const mapDispatchToProps = (dispatch: any) => {
     return {
         closeDialog: () => {
+            // TODO: this is a short-term hack.
+            // Can we instead subscribe to Redux action type == ActionType.CloseRequest,
+            // but narrow it down specically to the window instance (not application-wide)
+            window.document.dispatchEvent(new Event("Thorium:DialogClose"));
+
             dispatch(
                 dialogActions.close(),
             );

--- a/src/renderer/components/reader/Reader.tsx
+++ b/src/renderer/components/reader/Reader.tsx
@@ -334,6 +334,15 @@ export class Reader extends React.Component<ReaderProps, ReaderState> {
             }
         });
 
+        // TODO: this is a short-term hack.
+        // Can we instead subscribe to Redux action type == ActionType.CloseRequest,
+        // but narrow it down specically to a reader window instance (not application-wide)
+        window.document.addEventListener("Thorium:DialogClose", (ev: Event) => {
+            this.setState({
+                shortcutEnable: true,
+            });
+        });
+
         // tslint:disable-next-line:no-string-literal
         let docHref: string = queryParams["docHref"];
 
@@ -708,7 +717,8 @@ const mapDispatchToProps = (dispatch: any, props: ReaderProps) => {
         },
         displayPublicationInfo: (that: Reader) => {
             // TODO: subscribe to Redux action type == ActionType.CloseRequest
-            // in order to reset shortcutEnable to true
+            // in order to reset shortcutEnable to true? Problem: must be specific to this reader window.
+            // So instead we subscribe to DOM event "Thorium:DialogClose", but this is a short-term hack!
             that.setState({
                 shortcutEnable: false,
             });

--- a/src/renderer/components/reader/Reader.tsx
+++ b/src/renderer/components/reader/Reader.tsx
@@ -61,6 +61,10 @@ import { RootState } from "readium-desktop/renderer/redux/states";
 import { Store } from "redux";
 import { JSON as TAJSON } from "ta-json-x";
 
+import { DialogType } from "readium-desktop/common/models/dialog";
+import * as dialogActions from "readium-desktop/common/redux/actions/dialog";
+import { PublicationView } from "readium-desktop/common/views/publication";
+
 import optionsValues from "./options-values";
 
 import { withApi } from "readium-desktop/renderer/components/utils/api";
@@ -70,6 +74,10 @@ import * as queryString from "query-string";
 import { LocatorView } from "readium-desktop/common/views/locator";
 
 import * as styles from "readium-desktop/renderer/assets/styles/reader-app.css";
+
+import { Publication } from "readium-desktop/common/models/publication";
+
+import * as qs from "query-string";
 
 // import { registerProtocol } from "@r2-navigator-js/electron/renderer/common/protocol";
 // registerProtocol();
@@ -198,6 +206,8 @@ interface ReaderProps {
     detachReader?: any;
     setLastReadingLocation: any;
     bookmarks?: LocatorView[];
+    displayPublicationInfo?: any;
+    publication?: Publication;
 }
 
 const defaultLocale = "fr";
@@ -269,6 +279,8 @@ export class Reader extends React.Component<ReaderProps, ReaderState> {
         this.handleToggleBookmark = this.handleToggleBookmark.bind(this);
         this.goToLocator = this.goToLocator.bind(this);
         this.handleLinkClick = this.handleLinkClick.bind(this);
+
+        this.displayPublicationInfo = this.displayPublicationInfo.bind(this);
     }
 
     public async componentDidMount() {
@@ -395,6 +407,7 @@ export class Reader extends React.Component<ReaderProps, ReaderState> {
                             isOnBookmark={this.state.visibleBookmarkList.length > 0}
                             readerOptionsProps={readerOptionsProps}
                             readerMenuProps={readerMenuProps}
+                            displayPublicationInfo={this.displayPublicationInfo}
                         />
                         <div className={styles.content_root}>
                             <div className={styles.reader}>
@@ -413,6 +426,12 @@ export class Reader extends React.Component<ReaderProps, ReaderState> {
                     </div>
                 </div>
         );
+    }
+
+    private displayPublicationInfo() {
+        if (this.props.publication) {
+            this.props.displayPublicationInfo(this);
+        }
     }
 
     private goToLocator(locator: Locator) {
@@ -489,6 +508,7 @@ export class Reader extends React.Component<ReaderProps, ReaderState> {
     private handleMenuButtonClick() {
         this.setState({
             menuOpen: !this.state.menuOpen,
+            shortcutEnable: this.state.menuOpen,
             settingsOpen: false,
         });
     }
@@ -593,6 +613,7 @@ export class Reader extends React.Component<ReaderProps, ReaderState> {
     private handleSettingsClick() {
         this.setState({
             settingsOpen: !this.state.settingsOpen,
+            shortcutEnable: this.state.settingsOpen,
             menuOpen: false,
         });
     }
@@ -685,6 +706,26 @@ const mapDispatchToProps = (dispatch: any, props: ReaderProps) => {
         detachReader: (reader: any) => {
             dispatch(readerActions.detach(reader));
         },
+        displayPublicationInfo: (that: Reader) => {
+            // TODO: subscribe to Redux action type == ActionType.CloseRequest
+            // in order to reset shortcutEnable to true
+            that.setState({
+                shortcutEnable: false,
+            });
+            dispatch(dialogActions.open(
+                DialogType.PublicationInfoReader,
+                {
+                    publication: that.props.publication,
+                },
+            ));
+        },
+    };
+};
+
+const buildRequestData = (props: ReaderProps) => {
+    const parsedResult = qs.parse(document.location.href);
+    return {
+        identifier: parsedResult.pubId,
     };
 };
 
@@ -716,6 +757,13 @@ export default withApi(
                 moduleId: "reader",
                 methodId: "setLastReadingLocation",
                 callProp: "setLastReadingLocation",
+            },
+            {
+                moduleId: "publication",
+                methodId: "get",
+                buildRequestData,
+                resultProp: "publication",
+                onLoad: true,
             },
         ],
         refreshTriggers: [

--- a/src/renderer/components/reader/ReaderHeader.tsx
+++ b/src/renderer/components/reader/ReaderHeader.tsx
@@ -24,16 +24,10 @@ import * as QuitFullscreenIcon from "readium-desktop/renderer/assets/icons/sharp
 
 import SVG from "readium-desktop/renderer/components/utils/SVG";
 
-import { DialogType } from "readium-desktop/common/models/dialog";
-import * as dialogActions from "readium-desktop/common/redux/actions/dialog";
 import * as readerActions from "readium-desktop/common/redux/actions/reader";
-import { PublicationView } from "readium-desktop/common/views/publication";
 
 import { withApi } from "../utils/api";
 
-import { Publication } from "readium-desktop/common/models/publication";
-
-import * as qs from "query-string";
 import { ReaderMode } from "readium-desktop/common/models/reader";
 import { TranslatorProps, withTranslator } from "readium-desktop/renderer/components/utils/translator";
 
@@ -52,8 +46,7 @@ interface Props extends TranslatorProps {
     handleReaderDetach: () => void;
     toggleBookmark: any;
     isOnBookmark: boolean;
-    displayPublicationInfo?: any;
-    publication?: Publication;
+    displayPublicationInfo: any;
     readerMenuProps: any;
     readerOptionsProps: any;
 }
@@ -64,8 +57,6 @@ export class ReaderHeader extends React.Component<Props, undefined> {
 
     public constructor(props: Props) {
         super(props);
-
-        this.displayPublicationInfo = this.displayPublicationInfo.bind(this);
     }
 
     public componentDidUpdate(oldProps: Props) {
@@ -107,7 +98,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                         <li>
                             <button
                                 className={styles.menu_button}
-                                onClick={() => this.displayPublicationInfo()}
+                                onClick={() => this.props.displayPublicationInfo()}
                             >
                                 <SVG svg={InfosIcon} title={ __("reader.navigation.infoTitle")}/>
                             </button>
@@ -190,46 +181,6 @@ export class ReaderHeader extends React.Component<Props, undefined> {
             </nav>
         );
     }
-
-    private displayPublicationInfo() {
-        if (this.props.publication) {
-            this.props.displayPublicationInfo(this.props.publication);
-        }
-    }
 }
 
-const mapDispatchToProps = (dispatch: any, props: Props) => {
-    return {
-        displayPublicationInfo: (publication: PublicationView) => {
-            dispatch(dialogActions.open(
-                DialogType.PublicationInfoReader,
-                {
-                    publication,
-                },
-            ));
-        },
-    };
-};
-
-const buildRequestData = (props: Props) => {
-    const parsedResult = qs.parse(document.location.href);
-    return {
-        identifier: parsedResult.pubId,
-    };
-};
-
-export default withTranslator(withApi(
-    ReaderHeader,
-    {
-        mapDispatchToProps,
-        operations: [
-            {
-                moduleId: "publication",
-                methodId: "get",
-                buildRequestData,
-                resultProp: "publication",
-                onLoad: true,
-            },
-        ],
-    },
-));
+export default withTranslator(ReaderHeader);


### PR DESCRIPTION
Fixes https://github.com/readium/readium-desktop/issues/334

=> disables keyboard event listener when side menus are open, and modal popup dialog too (although this still needs some work, because we need to detect dialog close in order to restore keyboard arrows)