### PR TITLE
Fixes library view scroll extent (scrollbar was relative to full window height despite top header)

### DIFF
--- a/src/renderer/assets/styles/header.css
+++ b/src/renderer/assets/styles/header.css
@@ -123,7 +123,7 @@
 	&:focus {
 		right: 3.75rem;
 		width: fit-content;
-		top: 59px;
+		top: 0px;
 		z-index: 150;
 		height: 1rem;
 		font-size: 0.7rem;

--- a/src/renderer/assets/styles/myBooks.css
+++ b/src/renderer/assets/styles/myBooks.css
@@ -1,5 +1,4 @@
 main {
-    margin-top: 120px;
     height: auto;
     width: calc(100% - 120px);
     padding-left: 60px;

--- a/src/renderer/assets/styles/settings.css
+++ b/src/renderer/assets/styles/settings.css
@@ -1,5 +1,4 @@
 .main {
-    margin-top: 120px;
     height: auto;
     width: calc(100% - 120px);
     padding-left: 60px;

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -78,7 +78,7 @@ export default class App extends React.Component<any, undefined> {
                                     style={{
                                         position: "absolute",
                                         overflowX: "hidden",
-                                        top: 0,
+                                        top: 124,
                                         bottom: 0,
                                         left: 0,
                                         right: 0,


### PR DESCRIPTION
fixes https://github.com/readium/readium-desktop/issues/361
by swapping the top margin in scrolled content to the container's top offset