### PR TITLE
less tall top/bottom margins in reader view (wasted screen real estate)

### DIFF
--- a/src/renderer/assets/styles/reader-app.css
+++ b/src/renderer/assets/styles/reader-app.css
@@ -67,8 +67,8 @@
   height: 100%;
   display: flex;
   align-items: stretch;
-  margin-top: 6rem;
-  margin-bottom: 7.7rem;
+  margin-top: 1rem;
+  margin-bottom: 5rem;
 }
 
 /* ========== READER ==========*/


### PR DESCRIPTION
Fixes https://github.com/readium/readium-desktop/issues/338