### PR TITLE
[fix] electron-builder on mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,10 @@
         "MimeType": "application/epub+zip"
       }
     },
+    "mac": {
+      "target": "default",
+      "icon": "dist/assets/icons/icon.png"
+    },
     "appx": {
       "displayName": "Thorium Reader",
       "publisher": "CN=C91F86A8-45E6-48E0-8015-8A5BF2B38BD4"


### PR DESCRIPTION
fix `npm run package:mac` on mac-os