### PR TITLE
[fix #100] set the locale on plateform with 'en' fallback

### DIFF
--- a/src/common/redux/reducers/i18n.ts
+++ b/src/common/redux/reducers/i18n.ts
@@ -12,7 +12,7 @@ import { i18nActions } from "readium-desktop/common/redux/actions";
 import { I18NState } from "readium-desktop/common/redux/states/i18n";
 
 const initialState: I18NState = {
-    locale: 'en',
+    locale: "en",
 };
 
 export function i18nReducer(

--- a/src/common/redux/reducers/i18n.ts
+++ b/src/common/redux/reducers/i18n.ts
@@ -10,7 +10,6 @@ import { Action } from "readium-desktop/common/models/redux";
 import { i18nActions } from "readium-desktop/common/redux/actions";
 
 import { I18NState } from "readium-desktop/common/redux/states/i18n";
-import { app } from "electron";
 
 const initialState: I18NState = {
     locale: 'en',

--- a/src/common/redux/reducers/i18n.ts
+++ b/src/common/redux/reducers/i18n.ts
@@ -10,9 +10,10 @@ import { Action } from "readium-desktop/common/models/redux";
 import { i18nActions } from "readium-desktop/common/redux/actions";
 
 import { I18NState } from "readium-desktop/common/redux/states/i18n";
+import { app } from "electron";
 
 const initialState: I18NState = {
-    locale: "fr",
+    locale: 'en',
 };
 
 export function i18nReducer(

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,9 +38,9 @@ import {
 } from "@r2-shared-js/init-globals";
 
 import { getWindowsRectangle, savedWindowsRectangle } from "./common/rectangle/window";
-import { debounce } from "./utils/debounce";
 import { setLocale } from "./common/redux/actions/i18n";
 import { AvailableLanguages } from "./common/services/translator";
+import { debounce } from "./utils/debounce";
 
 if (_PACKAGING !== "0") {
     // Disable debug in packaged app
@@ -197,12 +197,11 @@ app.on("ready", async () => {
     debug("ready");
     initApp();
 
+    // set the locale from platform
     const store = container.get("store") as Store<RootState>;
-    store.dispatch(setLocale(
-        Object.keys(AvailableLanguages).reduce(
-            (pv, cv) => cv === app.getLocale().split("-")[0] ? cv : pv,
-            "en")
-    ));
+    const loc = app.getLocale().split("-")[0];
+    const lang = Object.keys(AvailableLanguages).find((l) => l === loc) || "en";
+    store.dispatch(setLocale(lang));
 
     if (!processCommandLine()) {
         // Do not open window if electron is launched as a command line

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,8 @@ import { CatalogService } from "readium-desktop/main/services/catalog";
 import { AppWindow, AppWindowType } from "readium-desktop/common/models/win";
 import { getWindowsRectangle, savedWindowsRectangle } from "./common/rectangle/window";
 import { debounce } from "./utils/debounce";
+import { setLocale } from "./common/redux/actions/i18n";
+import { AvailableLanguages } from "./common/services/translator";
 
 // Logger
 const debug = debug_("readium-desktop:main");
@@ -222,6 +224,13 @@ app.on("window-all-closed", () => {
 app.on("ready", async () => {
     debug("ready");
     initApp();
+
+    const store = container.get("store") as Store<RootState>;
+    store.dispatch(setLocale(
+        Object.keys(AvailableLanguages).reduce(
+            (pv, cv) => cv === app.getLocale().split('-')[0] ? cv : pv,
+            'en')
+    ));
 
     if (!processCommandLine()) {
         // Do not open window if electron is launched as a command line

--- a/src/main.ts
+++ b/src/main.ts
@@ -228,8 +228,8 @@ app.on("ready", async () => {
     const store = container.get("store") as Store<RootState>;
     store.dispatch(setLocale(
         Object.keys(AvailableLanguages).reduce(
-            (pv, cv) => cv === app.getLocale().split('-')[0] ? cv : pv,
-            'en')
+            (pv, cv) => cv === app.getLocale().split("-")[0] ? cv : pv,
+            "en")
     ));
 
     if (!processCommandLine()) {


### PR DESCRIPTION
- add en per default in redux
- dispatch in app.ready the platform local