### PR TITLE
catch focus on tab menu reader when is closed

### DIFF
--- a/src/renderer/components/reader/ReaderHeader.tsx
+++ b/src/renderer/components/reader/ReaderHeader.tsx
@@ -34,6 +34,8 @@ import { TranslatorProps, withTranslator } from "readium-desktop/renderer/compon
 import ReaderMenu from "./ReaderMenu";
 import ReaderOptions from "./ReaderOptions";
 
+import {createRef} from "react";
+
 interface Props extends TranslatorProps {
     menuOpen: boolean;
     mode?: ReaderMode;
@@ -52,10 +54,10 @@ interface Props extends TranslatorProps {
 }
 
 export class ReaderHeader extends React.Component<Props, undefined> {
-    private enableFullscreenRef: any;
-    private disableFullscreenRef: any;
-    private catchSettingFocus: any;
-    private catchMenuFocus: any;
+    private enableFullscreenRef = createRef<HTMLButtonElement>();
+    private disableFullscreenRef = createRef<HTMLButtonElement>();
+    private catchSettingFocus = createRef<HTMLButtonElement>();
+    private catchMenuFocus = createRef<HTMLButtonElement>();
 
     public constructor(props: Props) {
         super(props);
@@ -63,21 +65,21 @@ export class ReaderHeader extends React.Component<Props, undefined> {
 
     public componentDidUpdate(oldProps: Props) {
         if (this.props.fullscreen !== oldProps.fullscreen) {
-            if (this.props.fullscreen) {
-                this.disableFullscreenRef.focus();
-            } else {
-                this.enableFullscreenRef.focus();
+            if (this.props.fullscreen && this.disableFullscreenRef.current) {
+                this.disableFullscreenRef.current.focus();
+            } else if (!this.props.fullscreen && this.enableFullscreenRef.current) {
+                this.enableFullscreenRef.current.focus();
             }
         }
 
         if (this.props.settingsOpen !== oldProps.settingsOpen &&
-            this.props.settingsOpen === false) {
-                this.catchSettingFocus.focus();
+            this.props.settingsOpen === false && this.catchSettingFocus.current) {
+                this.catchSettingFocus.current.focus();
         }
 
         if (this.props.menuOpen !== oldProps.menuOpen &&
-            this.props.menuOpen === false) {
-                this.catchMenuFocus.focus();
+            this.props.menuOpen === false && this.catchMenuFocus.current) {
+                this.catchMenuFocus.current.focus();
             }
     }
 
@@ -130,7 +132,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             <button
                                 className={styles.menu_button}
                                 onClick={this.props.handleFullscreenClick}
-                                ref={(ref) => this.enableFullscreenRef = ref}
+                                ref={this.enableFullscreenRef}
                             >
                                 <SVG svg={FullscreenIcon} title={ __("reader.navigation.fullscreenTitle")}/>
                             </button>
@@ -142,7 +144,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             <button
                                 className={styles.menu_button}
                                 onClick={this.props.handleMenuClick.bind(this)}
-                                ref={(ref) => this.catchMenuFocus = ref}
+                                ref={this.catchMenuFocus}
                             >
                                 <SVG svg={TOCIcon} title={ __("reader.navigation.openTableOfContentsTitle")}/>
                             </button>
@@ -155,7 +157,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             <button
                                 className={styles.menu_button}
                                 onClick={this.props.handleSettingsClick.bind(this)}
-                                ref={(ref) => this.catchSettingFocus = ref}
+                                ref={this.catchSettingFocus}
                             >
                                 <SVG svg={SettingsIcon} title={ __("reader.navigation.settingsTitle")}/>
                             </button>
@@ -185,7 +187,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                         <button
                             className={styles.menu_button}
                             onClick={this.props.handleFullscreenClick}
-                            ref={(ref) => this.disableFullscreenRef = ref}
+                            ref={this.disableFullscreenRef}
                         >
                             <SVG svg={QuitFullscreenIcon} title={ __("reader.navigation.quitFullscreenTitle")}/>
                         </button>

--- a/src/renderer/components/reader/ReaderHeader.tsx
+++ b/src/renderer/components/reader/ReaderHeader.tsx
@@ -54,6 +54,8 @@ interface Props extends TranslatorProps {
 export class ReaderHeader extends React.Component<Props, undefined> {
     private enableFullscreenRef: any;
     private disableFullscreenRef: any;
+    private catchSettingFocus: any;
+    private catchMenuFocus: any;
 
     public constructor(props: Props) {
         super(props);
@@ -67,6 +69,16 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                 this.enableFullscreenRef.focus();
             }
         }
+
+        if (this.props.settingsOpen !== oldProps.settingsOpen &&
+            this.props.settingsOpen === false) {
+                this.catchSettingFocus.focus();
+        }
+
+        if (this.props.menuOpen !== oldProps.menuOpen &&
+            this.props.menuOpen === false) {
+                this.catchMenuFocus.focus();
+            }
     }
 
     public render(): React.ReactElement<{}> {
@@ -130,6 +142,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             <button
                                 className={styles.menu_button}
                                 onClick={this.props.handleMenuClick.bind(this)}
+                                ref={(ref) => this.catchMenuFocus = ref}
                             >
                                 <SVG svg={TOCIcon} title={ __("reader.navigation.openTableOfContentsTitle")}/>
                             </button>
@@ -142,9 +155,11 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             <button
                                 className={styles.menu_button}
                                 onClick={this.props.handleSettingsClick.bind(this)}
+                                ref={(ref) => this.catchSettingFocus = ref}
                             >
                                 <SVG svg={SettingsIcon} title={ __("reader.navigation.settingsTitle")}/>
                             </button>
+                            <ReaderOptions {...this.props.readerOptionsProps}/>
                         </li>
                         <li
                             className={styles.right}
@@ -157,7 +172,6 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             >
                                 <SVG svg={MarkIcon} title={ __("reader.navigation.bookmarkTitle")}/>
                             </button>
-                            <ReaderOptions {...this.props.readerOptionsProps}/>
                         </li>
                         {/*<li className={styles.right}>
                             <button

--- a/src/renderer/components/reader/ReaderHeader.tsx
+++ b/src/renderer/components/reader/ReaderHeader.tsx
@@ -35,6 +35,7 @@ import ReaderMenu from "./ReaderMenu";
 import ReaderOptions from "./ReaderOptions";
 
 import {createRef} from "react";
+import ReactDOM = require("react-dom");
 
 interface Props extends TranslatorProps {
     menuOpen: boolean;
@@ -61,6 +62,9 @@ export class ReaderHeader extends React.Component<Props, undefined> {
 
     public constructor(props: Props) {
         super(props);
+
+        this.focusSettingMenuButton = this.focusSettingMenuButton.bind(this);
+        this.focusNaviguationMenuButton = this.focusNaviguationMenuButton.bind(this);
     }
 
     public componentDidUpdate(oldProps: Props) {
@@ -71,16 +75,6 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                 this.enableFullscreenRef.current.focus();
             }
         }
-
-        if (this.props.settingsOpen !== oldProps.settingsOpen &&
-            this.props.settingsOpen === false && this.settingsMenuButtonRef.current) {
-                this.settingsMenuButtonRef.current.focus();
-        }
-
-        if (this.props.menuOpen !== oldProps.menuOpen &&
-            this.props.menuOpen === false && this.navigationMenuButtonRef.current) {
-                this.navigationMenuButtonRef.current.focus();
-            }
     }
 
     public render(): React.ReactElement<{}> {
@@ -148,7 +142,8 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             >
                                 <SVG svg={TOCIcon} title={ __("reader.navigation.openTableOfContentsTitle")}/>
                             </button>
-                            <ReaderMenu {...this.props.readerMenuProps}/>
+                            <ReaderMenu {...this.props.readerMenuProps}
+                            focusNaviguationMenu={this.focusNaviguationMenuButton}/>
                         </li>
                         <li
                             className={styles.right}
@@ -161,7 +156,8 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             >
                                 <SVG svg={SettingsIcon} title={ __("reader.navigation.settingsTitle")}/>
                             </button>
-                            <ReaderOptions {...this.props.readerOptionsProps}/>
+                            <ReaderOptions {...this.props.readerOptionsProps}
+                            focusSettingMenuButton={this.focusSettingMenuButton}/>
                         </li>
                         <li
                             className={styles.right}
@@ -196,6 +192,17 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                 </ul>
             </nav>
         );
+    }
+    private focusSettingMenuButton() {
+        const button = ReactDOM.findDOMNode(this.settingsMenuButtonRef.current) as HTMLButtonElement;
+
+        button.focus();
+    }
+
+    private focusNaviguationMenuButton() {
+        const button = ReactDOM.findDOMNode(this.navigationMenuButtonRef.current) as HTMLButtonElement;
+
+        button.focus();
     }
 }
 

--- a/src/renderer/components/reader/ReaderHeader.tsx
+++ b/src/renderer/components/reader/ReaderHeader.tsx
@@ -56,8 +56,8 @@ interface Props extends TranslatorProps {
 export class ReaderHeader extends React.Component<Props, undefined> {
     private enableFullscreenRef = createRef<HTMLButtonElement>();
     private disableFullscreenRef = createRef<HTMLButtonElement>();
-    private catchSettingFocus = createRef<HTMLButtonElement>();
-    private catchMenuFocus = createRef<HTMLButtonElement>();
+    private settingsMenuButtonRef = createRef<HTMLButtonElement>();
+    private navigationMenuButtonRef = createRef<HTMLButtonElement>();
 
     public constructor(props: Props) {
         super(props);
@@ -73,13 +73,13 @@ export class ReaderHeader extends React.Component<Props, undefined> {
         }
 
         if (this.props.settingsOpen !== oldProps.settingsOpen &&
-            this.props.settingsOpen === false && this.catchSettingFocus.current) {
-                this.catchSettingFocus.current.focus();
+            this.props.settingsOpen === false && this.settingsMenuButtonRef.current) {
+                this.settingsMenuButtonRef.current.focus();
         }
 
         if (this.props.menuOpen !== oldProps.menuOpen &&
-            this.props.menuOpen === false && this.catchMenuFocus.current) {
-                this.catchMenuFocus.current.focus();
+            this.props.menuOpen === false && this.navigationMenuButtonRef.current) {
+                this.navigationMenuButtonRef.current.focus();
             }
     }
 
@@ -144,7 +144,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             <button
                                 className={styles.menu_button}
                                 onClick={this.props.handleMenuClick.bind(this)}
-                                ref={this.catchMenuFocus}
+                                ref={this.navigationMenuButtonRef}
                             >
                                 <SVG svg={TOCIcon} title={ __("reader.navigation.openTableOfContentsTitle")}/>
                             </button>
@@ -157,7 +157,7 @@ export class ReaderHeader extends React.Component<Props, undefined> {
                             <button
                                 className={styles.menu_button}
                                 onClick={this.props.handleSettingsClick.bind(this)}
-                                ref={this.catchSettingFocus}
+                                ref={this.settingsMenuButtonRef}
                             >
                                 <SVG svg={SettingsIcon} title={ __("reader.navigation.settingsTitle")}/>
                             </button>

--- a/src/renderer/components/reader/ReaderMenu.tsx
+++ b/src/renderer/components/reader/ReaderMenu.tsx
@@ -40,6 +40,7 @@ interface Props extends TranslatorProps {
     handleBookmarkClick: (locator: any) => void;
     deleteBookmark?: any;
     toggleMenu: any;
+    focusNaviguationMenu: () => void;
 }
 
 interface State {
@@ -96,6 +97,7 @@ export class ReaderMenu extends React.Component<Props, State> {
                 open={this.props.open}
                 sections={sections}
                 toggleMenu={toggleMenu}
+                focusMenuButton={this.props.focusNaviguationMenu}
             />
         );
     }

--- a/src/renderer/components/reader/ReaderOptions.tsx
+++ b/src/renderer/components/reader/ReaderOptions.tsx
@@ -43,6 +43,7 @@ interface Props extends TranslatorProps {
     handleIndexChange: (event: any, name: string, value?: any) => void;
     setSettings: (settings: any) => void;
     toggleMenu: any;
+    focusSettingMenuButton: () => void;
 }
 
 enum themeType {
@@ -93,6 +94,7 @@ export class ReaderOptions extends React.Component<Props> {
                 open={this.props.open}
                 sections={sections}
                 toggleMenu={toggleMenu}
+                focusMenuButton={this.props.focusSettingMenuButton}
             />
         );
     }

--- a/src/renderer/components/reader/sideMenu/SideMenu.tsx
+++ b/src/renderer/components/reader/sideMenu/SideMenu.tsx
@@ -54,7 +54,7 @@ export class SideMenu extends React.Component<Props, State> {
             focusMenuButton = {this.props.focusMenuButton}
             className={className}
             visible={open}
-             toggleMenu={toggleMenu}>
+            toggleMenu={toggleMenu}>
                 <ul id={listClassName}>
                     { sections.map((section, index) =>
                         <SideMenuSection

--- a/src/renderer/components/reader/sideMenu/SideMenu.tsx
+++ b/src/renderer/components/reader/sideMenu/SideMenu.tsx
@@ -22,6 +22,7 @@ interface Props extends TranslatorProps {
     className: string;
     listClassName: string;
     toggleMenu: any;
+    focusMenuButton: () => void;
 }
 
 interface State {
@@ -48,7 +49,12 @@ export class SideMenu extends React.Component<Props, State> {
         }
 
         return (<>
-            <AccessibleMenu dontCloseWhenClickOutside className={className} visible={open} toggleMenu={toggleMenu}>
+            <AccessibleMenu
+            dontCloseWhenClickOutside
+            focusMenuButton = {this.props.focusMenuButton}
+            className={className}
+            visible={open}
+             toggleMenu={toggleMenu}>
                 <ul id={listClassName}>
                     { sections.map((section, index) =>
                         <SideMenuSection

--- a/src/renderer/components/utils/menu/AccessibleMenu.tsx
+++ b/src/renderer/components/utils/menu/AccessibleMenu.tsx
@@ -63,18 +63,17 @@ export default class AccessibleMenu extends React.Component<Props, State> {
             document.removeEventListener("keydown", this.handleKey);
             document.removeEventListener("focusin", this.handleFocus);
             if (this.ismounted) {
-            this.setState({
-                inFocus: false,
-            });
+                this.setState({
+                    inFocus: false,
+                });
             }
         } else if (this.props.visible && !oldProps.visible) {
             document.addEventListener("keydown", this.handleKey);
             document.addEventListener("focusin", this.handleFocus);
             if (this.ismounted) {
-
-            this.setState({
-                triggerElem: document.activeElement,
-            });
+                this.setState({
+                    triggerElem: document.activeElement,
+                });
             }
         }
 

--- a/src/renderer/components/utils/menu/AccessibleMenu.tsx
+++ b/src/renderer/components/utils/menu/AccessibleMenu.tsx
@@ -26,6 +26,7 @@ interface State {
 
 export default class AccessibleMenu extends React.Component<Props, State> {
     private containerRef: any;
+    private ismounted = false;
 
     public constructor(props: Props) {
         super(props);
@@ -42,6 +43,7 @@ export default class AccessibleMenu extends React.Component<Props, State> {
     }
 
     public componentDidMount() {
+        this.ismounted = true;
         if (this.props.visible) {
             document.addEventListener("keydown", this.handleKey);
             document.addEventListener("focusin", this.handleFocus);
@@ -49,6 +51,7 @@ export default class AccessibleMenu extends React.Component<Props, State> {
     }
 
     public componentWillUnmount() {
+        this.ismounted = false;
         if (this.props.visible) {
             document.removeEventListener("keydown", this.handleKey);
             document.removeEventListener("focusin", this.handleFocus);
@@ -59,17 +62,20 @@ export default class AccessibleMenu extends React.Component<Props, State> {
         if (!this.props.visible && oldProps.visible) {
             document.removeEventListener("keydown", this.handleKey);
             document.removeEventListener("focusin", this.handleFocus);
-
+            if (this.ismounted) {
             this.setState({
                 inFocus: false,
             });
+            }
         } else if (this.props.visible && !oldProps.visible) {
             document.addEventListener("keydown", this.handleKey);
             document.addEventListener("focusin", this.handleFocus);
+            if (this.ismounted) {
 
             this.setState({
                 triggerElem: document.activeElement,
             });
+            }
         }
 
         if (prevState.inFocus
@@ -103,16 +109,23 @@ export default class AccessibleMenu extends React.Component<Props, State> {
     private handleKey(event: any) {
         if (event.key === "Escape" || (!this.state.inFocus && (event.shiftKey && event.key === "Tab"))) {
             this.props.toggleMenu();
-            this.props.focusMenuButton();
-            this.setState({
-                inFocus: false,
-            });
+            if (this.props.focusMenuButton) {
+                this.props.focusMenuButton();
+            }
+            if (this.ismounted) {
+                this.setState({
+                    inFocus: false,
+                });
+            }
         }
         if (event.key === "Tab" && !this.state.inFocus) {
             event.preventDefault();
-            this.setState({
-                inFocus: true,
-            });
+            if (this.ismounted) {
+                this.setState({
+                    inFocus: true,
+                });
+            }
+
         }
     }
 
@@ -129,9 +142,11 @@ export default class AccessibleMenu extends React.Component<Props, State> {
             && this.containerRef.current
             && this.containerRef.current.contains(focusedNode)
         ) {
-            this.setState({
+            if (this.ismounted) {
+                this.setState({
                 inFocus: true,
-            });
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
this PR allow to find back the focus in reader when we closed settings and navigation menu

fixes #336 