### PR TITLE
asarUnpack for native NodeJS *.node libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,10 @@
       "main.js",
       "package.json"
     ],
+    "asarUnpack": [
+      "**/*.node",
+      "!**/lcp.node"
+    ],
     "directories": {
       "buildResources": "resources",
       "output": "release",


### PR DESCRIPTION
 (ensures support for Windows 10S), ... except for LCP lib.

Fixes https://github.com/readium/readium-desktop/issues/387