### PR TITLE
[fix #292] info button works now

### DIFF
--- a/src/renderer/components/reader/Reader.tsx
+++ b/src/renderer/components/reader/Reader.tsx
@@ -757,9 +757,8 @@ const mapDispatchToProps = (dispatch: any, props: ReaderProps) => {
 };
 
 const buildRequestData = (props: ReaderProps) => {
-    const parsedResult = qs.parse(document.location.href);
     return {
-        identifier: parsedResult.pubId,
+        identifier: queryParams.pubId,
     };
 };
 


### PR DESCRIPTION
[fix] at the first opening of an publication the end of url is [pubId]#/ and qs module doesn't understand '#/'

I used 'queryParams' fct from r2-navigator already used in reader.tsx.

fixes #292 

