### PR TITLE
fix(10n): updated codebase static analyzer to capture dynamic locale keys used in notification toasts

### DIFF
--- a/scripts/translate-scan.js
+++ b/scripts/translate-scan.js
@@ -28,7 +28,7 @@ glob("src/**/*{.ts,.tsx}", {}, function (err, files) {
         const fileTxt = fs.readFileSync(path.join(process.cwd(), file), { encoding: "utf8" });
 
         // (\.translate|__)\s*\(\s*['"]\s*([^'"]+)['"]
-        const regex = new RegExp(`(\.translate|__)\\s*\\(\\s*['"]([^'"]+)['"]`, "g");
+        const regex = new RegExp(`(\\.translate|__)\\s*\\(\\s*['"]([^'"]+)['"]`, "g");
 
         let regexMatch = regex.exec(fileTxt);
         while (regexMatch) {
@@ -41,6 +41,22 @@ glob("src/**/*{.ts,.tsx}", {}, function (err, files) {
                 console.log(`-- duplicate: ${key}`);
             }
             regexMatch = regex.exec(fileTxt);
+        }
+
+        // dispatchToastRequest\s*\(\s*ToastType\.[^"']+['"]([^'"]+)['"]
+        const regex2 = new RegExp(`dispatchToastRequest\\s*\\(\\s*ToastType\\.[^"']+['"]([^'"]+)['"]`, "g");
+
+        regexMatch = regex2.exec(fileTxt);
+        while (regexMatch) {
+            totalMatch++;
+            const key = regexMatch[1];
+            if (!keys.includes(key)) {
+                keys.push(key);
+                console.log(key);
+            } else {
+                console.log(`-- duplicate: ${key}`);
+            }
+            regexMatch = regex2.exec(fileTxt);
         }
     }
 

--- a/src/resources/locales/de.json
+++ b/src/resources/locales/de.json
@@ -58,7 +58,6 @@
         "alreadyAdd": "Es scheint, dass Sie diese Publikation bereits in Ihren Katalog aufgenommen haben.",
         "closeModalWindow": "Dieses modale Fenster schließen",
         "delete": "Willst du diese Publikation wirklich löschen?",
-        "deleteOpds": "",
         "import": "Willst du diese EPUB-Dateien wirklich importieren?",
         "importError": "ein Fehler ist aufgetreten, überprüfen Sie Ihre Dateiendung (.epub or .lcpl).",
         "no": "Nein",
@@ -80,37 +79,12 @@
         "settings": "Settings"
     },
     "library": {
-        "add": "Zur Bibliothek hinzufügen",
-        "cancelDownload": "Ein Download wurde abgebrochen.",
-        "endDownload": "Ein Download wurde beendet.",
-        "heading": "Bibliothek",
         "lcp": {
             "cancel": "Abbrechen",
             "hint": "Dein Kennwort",
-            "informations": {
-                "close": "Schließen",
-                "issued": "Ausstellungsdatum:",
-                "provider": "Aussteller:",
-                "right": {
-                    "copy": "Nummer der Kopie:",
-                    "end": "Ende:",
-                    "print": "Nummer des gedruckten Werks:",
-                    "start": "Start:",
-                    "title": "Rechte"
-                },
-                "title": "LCP-Informationen",
-                "updated": "Aktualisiert:"
-            },
             "password": "",
             "sentence": "Diese Publikation benötigt zum Öffnen ein LCP-Password: ",
-            "submit": "Absenden",
-            "title": "LCP-Verifikation"
-        },
-        "startDownload": "Ein Download wurde gestartet.",
-        "svg": {
-            "card": "",
-            "list": "",
-            "showParaphrase": ""
+            "submit": "Absenden"
         }
     },
     "message": {
@@ -120,41 +94,21 @@
         },
         "import": {
             "success": ""
-        },
-        "lcp": {
-            "passphraseError": "Konnte die Publikation {{publicationTitle}} nicht entsperren",
-            "renewError": "Beim Verlängern der LCP-Lizenz von {{title}} trat ein Fehler auf",
-            "renewSuccess": "Die LCP-Lizenz von {{title}} wurde verlängert",
-            "returnError": "Beim Zurückgeben der LCP-Lizenz von {{title}} trat ein Fehler auf",
-            "returnSuccess": "Die LCP-Lizenz von {{title}} wurde zurückgegeben"
         }
     },
     "opds": {
         "addForm": {
             "addButton": "Hinzufügen",
-            "addSentence": "Welchen ODPS-Feed willst du hinzufügen?",
-            "delete": "Feed löschen",
             "name": "Feed-Name:",
             "namePlaceholder": "",
             "pasteUrl": "die URL eines Futters einfügen",
             "title": "Feed hinzufügen",
-            "update": "Aktualisieren",
-            "updateSentence": "Du kannst die Felder aktualisieren.",
             "url": "Feed-Link:",
             "urlPlaceholder": ""
         },
         "addMenu": "OPDS-Feed hinzufügen",
-        "authentication": {
-            "loginButton": "Login",
-            "password": "Passwort:",
-            "sentence": "Bitte logge dich ein, um auf die Inhalte zuzugreifen",
-            "username": "Benutzername:"
-        },
         "back": "Zurück",
         "breadcrumbRoot": "",
-        "download": "Download",
-        "downloadError": "Beim Abrufen des Feeds trat ein Fehler auf.",
-        "formError": "Bitte fülle alle Felder aus",
         "menu": {
             "aboutBook": "über dieses Buch",
             "addExtract": "zur Lib hinzufügen",
@@ -162,27 +116,14 @@
             "goBuyBook": "dieses Buch kaufen",
             "goLoanBook": "dieses Buch ausleihen",
             "goSubBook": "abonnieren"
-        },
-        "settings": "Einstellungen",
-        "svg": {
-            "opds": ""
         }
     },
     "publication": {
-        "cancelDownloadButton": "Abbrechen",
-        "canceledDownload": "Download abgebrochen",
         "deleteButton": "Löschen",
-        "downloadButton": "Download",
-        "endDownload": "Download abgeschlossen",
         "expiredLcp": "",
-        "failedDownload": "Download fehlerhaft",
-        "infoButton": "LCP-Informationen",
-        "progressDownload": "Download läuft",
         "readButton": "Lesen",
         "renewButton": "Verlängern",
-        "renewSentence": "Bist du sicher, dass die Publikation verlängert werden soll?",
         "returnButton": "Zurückgeben",
-        "returnSentence": "Bist du sicher, dass die Publikation zurückgegeben werden soll?",
         "returnedLcp": "",
         "revokedLcp": "",
         "seeLess": "Weniger Infos",
@@ -197,7 +138,6 @@
             "annotations": "Annotationen",
             "bookmarks": "Lesezeichen",
             "illustrations": "Illustrationstabelle",
-            "landmarks": "Sehenswürdigkeiten",
             "toc": "inhaltsverzeichnis"
         },
         "navigation": {
@@ -212,8 +152,6 @@
             "settingsTitle": "settings"
         },
         "settings": {
-            "DefaultFont": "Standardschrift",
-            "accessibility": "",
             "column": {
                 "auto": "",
                 "one": "",
@@ -224,9 +162,7 @@
             },
             "display": "Lesefluss",
             "disposition": {
-                "title": "",
-                "with": "",
-                "without": ""
+                "title": ""
             },
             "font": "",
             "fontSize": "Schriftgröße:",
@@ -237,36 +173,22 @@
             "lineSpacing": "",
             "margin": "",
             "paginated": "Seitendarstellung",
-            "right": "Rechtsbündig",
             "scrolled": "Fortlaufend",
             "spacing": "Abstand",
             "text": "Text",
             "theme": {
-                "create": "ein Thema erstellen",
-                "myTheme": "meine Themen",
                 "name": {
                     "Neutral": "Neutral",
                     "Night": "Nachtzeit",
                     "Sepia": "Sepia"
                 },
-                "predefined": "vordefiniertes Thema",
                 "title": "Thema"
             },
-            "title": "Einstellungen",
             "wordSpacing": ""
         },
         "svg": {
-            "alignCenter": "",
-            "alignLeft": "",
-            "alignRight": "",
-            "contentTable": "",
-            "continue": "",
-            "document": "",
-            "landmark": "",
             "left": "",
-            "night": "",
-            "right": "",
-            "settings": ""
+            "right": ""
         }
     },
     "settings": {
@@ -274,23 +196,6 @@
         "language": {
             "languageChoice": "Sprachauswahl"
         },
-        "manageTags": "Manage tags",
         "uiLanguage": "Sprache"
-    },
-    "toolbar": {
-        "about": "Über",
-        "help": "Hilfe",
-        "news": "Neuerungen",
-        "svg": {
-            "addEpub": "",
-            "help": "",
-            "news": "",
-            "opds": "",
-            "others": ""
-        },
-        "sync": "Synchronisiere die Bibliothek"
-    },
-    "update": {
-        "available": "Update verfügbar!"
     }
 }

--- a/src/resources/locales/de.json
+++ b/src/resources/locales/de.json
@@ -58,6 +58,7 @@
         "alreadyAdd": "Es scheint, dass Sie diese Publikation bereits in Ihren Katalog aufgenommen haben.",
         "closeModalWindow": "Dieses modale Fenster schließen",
         "delete": "Willst du diese Publikation wirklich löschen?",
+        "deleteOpds": "",
         "import": "Willst du diese EPUB-Dateien wirklich importieren?",
         "importError": "ein Fehler ist aufgetreten, überprüfen Sie Ihre Dateiendung (.epub or .lcpl).",
         "no": "Nein",
@@ -79,27 +80,81 @@
         "settings": "Settings"
     },
     "library": {
+        "add": "Zur Bibliothek hinzufügen",
+        "cancelDownload": "Ein Download wurde abgebrochen.",
+        "endDownload": "Ein Download wurde beendet.",
+        "heading": "Bibliothek",
         "lcp": {
             "cancel": "Abbrechen",
             "hint": "Dein Kennwort",
+            "informations": {
+                "close": "Schließen",
+                "issued": "Ausstellungsdatum:",
+                "provider": "Aussteller:",
+                "right": {
+                    "copy": "Nummer der Kopie:",
+                    "end": "Ende:",
+                    "print": "Nummer des gedruckten Werks:",
+                    "start": "Start:",
+                    "title": "Rechte"
+                },
+                "title": "LCP-Informationen",
+                "updated": "Aktualisiert:"
+            },
             "password": "",
             "sentence": "Diese Publikation benötigt zum Öffnen ein LCP-Password: ",
-            "submit": "Absenden"
+            "submit": "Absenden",
+            "title": "LCP-Verifikation"
+        },
+        "startDownload": "Ein Download wurde gestartet.",
+        "svg": {
+            "card": "",
+            "list": "",
+            "showParaphrase": ""
+        }
+    },
+    "message": {
+        "download": {
+            "start": "Der Download von {{title}} hat begonnen",
+            "success": "Der Download von {{title}} wurde abgeschlossen"
+        },
+        "import": {
+            "success": ""
+        },
+        "lcp": {
+            "passphraseError": "Konnte die Publikation {{publicationTitle}} nicht entsperren",
+            "renewError": "Beim Verlängern der LCP-Lizenz von {{title}} trat ein Fehler auf",
+            "renewSuccess": "Die LCP-Lizenz von {{title}} wurde verlängert",
+            "returnError": "Beim Zurückgeben der LCP-Lizenz von {{title}} trat ein Fehler auf",
+            "returnSuccess": "Die LCP-Lizenz von {{title}} wurde zurückgegeben"
         }
     },
     "opds": {
         "addForm": {
             "addButton": "Hinzufügen",
+            "addSentence": "Welchen ODPS-Feed willst du hinzufügen?",
+            "delete": "Feed löschen",
             "name": "Feed-Name:",
             "namePlaceholder": "",
             "pasteUrl": "die URL eines Futters einfügen",
             "title": "Feed hinzufügen",
+            "update": "Aktualisieren",
+            "updateSentence": "Du kannst die Felder aktualisieren.",
             "url": "Feed-Link:",
             "urlPlaceholder": ""
         },
         "addMenu": "OPDS-Feed hinzufügen",
+        "authentication": {
+            "loginButton": "Login",
+            "password": "Passwort:",
+            "sentence": "Bitte logge dich ein, um auf die Inhalte zuzugreifen",
+            "username": "Benutzername:"
+        },
         "back": "Zurück",
         "breadcrumbRoot": "",
+        "download": "Download",
+        "downloadError": "Beim Abrufen des Feeds trat ein Fehler auf.",
+        "formError": "Bitte fülle alle Felder aus",
         "menu": {
             "aboutBook": "über dieses Buch",
             "addExtract": "zur Lib hinzufügen",
@@ -107,14 +162,27 @@
             "goBuyBook": "dieses Buch kaufen",
             "goLoanBook": "dieses Buch ausleihen",
             "goSubBook": "abonnieren"
+        },
+        "settings": "Einstellungen",
+        "svg": {
+            "opds": ""
         }
     },
     "publication": {
+        "cancelDownloadButton": "Abbrechen",
+        "canceledDownload": "Download abgebrochen",
         "deleteButton": "Löschen",
+        "downloadButton": "Download",
+        "endDownload": "Download abgeschlossen",
         "expiredLcp": "",
+        "failedDownload": "Download fehlerhaft",
+        "infoButton": "LCP-Informationen",
+        "progressDownload": "Download läuft",
         "readButton": "Lesen",
         "renewButton": "Verlängern",
+        "renewSentence": "Bist du sicher, dass die Publikation verlängert werden soll?",
         "returnButton": "Zurückgeben",
+        "returnSentence": "Bist du sicher, dass die Publikation zurückgegeben werden soll?",
         "returnedLcp": "",
         "revokedLcp": "",
         "seeLess": "Weniger Infos",
@@ -129,6 +197,7 @@
             "annotations": "Annotationen",
             "bookmarks": "Lesezeichen",
             "illustrations": "Illustrationstabelle",
+            "landmarks": "Sehenswürdigkeiten",
             "toc": "inhaltsverzeichnis"
         },
         "navigation": {
@@ -143,6 +212,8 @@
             "settingsTitle": "settings"
         },
         "settings": {
+            "DefaultFont": "Standardschrift",
+            "accessibility": "",
             "column": {
                 "auto": "",
                 "one": "",
@@ -153,7 +224,9 @@
             },
             "display": "Lesefluss",
             "disposition": {
-                "title": ""
+                "title": "",
+                "with": "",
+                "without": ""
             },
             "font": "",
             "fontSize": "Schriftgröße:",
@@ -164,22 +237,36 @@
             "lineSpacing": "",
             "margin": "",
             "paginated": "Seitendarstellung",
+            "right": "Rechtsbündig",
             "scrolled": "Fortlaufend",
             "spacing": "Abstand",
             "text": "Text",
             "theme": {
+                "create": "ein Thema erstellen",
+                "myTheme": "meine Themen",
                 "name": {
                     "Neutral": "Neutral",
                     "Night": "Nachtzeit",
                     "Sepia": "Sepia"
                 },
+                "predefined": "vordefiniertes Thema",
                 "title": "Thema"
             },
+            "title": "Einstellungen",
             "wordSpacing": ""
         },
         "svg": {
+            "alignCenter": "",
+            "alignLeft": "",
+            "alignRight": "",
+            "contentTable": "",
+            "continue": "",
+            "document": "",
+            "landmark": "",
             "left": "",
-            "right": ""
+            "night": "",
+            "right": "",
+            "settings": ""
         }
     },
     "settings": {
@@ -187,6 +274,23 @@
         "language": {
             "languageChoice": "Sprachauswahl"
         },
+        "manageTags": "Manage tags",
         "uiLanguage": "Sprache"
+    },
+    "toolbar": {
+        "about": "Über",
+        "help": "Hilfe",
+        "news": "Neuerungen",
+        "svg": {
+            "addEpub": "",
+            "help": "",
+            "news": "",
+            "opds": "",
+            "others": ""
+        },
+        "sync": "Synchronisiere die Bibliothek"
+    },
+    "update": {
+        "available": "Update verfügbar!"
     }
 }

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -58,7 +58,6 @@
         "alreadyAdd": "It seems that you have already added this publication to your library.",
         "closeModalWindow": "Close this modal window",
         "delete": "Do you really want to delete this publication?",
-        "deleteOpds": "Do you really want to delete this opds feed?",
         "import": "Do you really want to import those EPUB files :",
         "importError": "an error occured, verify your file extension (.epub or .lcpl)",
         "no": "No",
@@ -80,37 +79,12 @@
         "settings": "Settings"
     },
     "library": {
-        "add": "Add to the library",
-        "cancelDownload": "A download canceled.",
-        "endDownload": "A download ended.",
-        "heading": "Library",
         "lcp": {
             "cancel": "Cancel",
             "hint": "(Hint : {{hint}})",
-            "informations": {
-                "close": "Close",
-                "issued": "Creation date:",
-                "provider": "Provider:",
-                "right": {
-                    "copy": "Copy number:",
-                    "end": "End:",
-                    "print": "Print number:",
-                    "start": "Start:",
-                    "title": "Rights"
-                },
-                "title": "LCP Informations",
-                "updated": "Updated:"
-            },
             "password": "Password",
             "sentence": "This publication needs a LCP password to be opened: ",
-            "submit": "Submit",
-            "title": "LCP Verification"
-        },
-        "startDownload": "A download started.",
-        "svg": {
-            "card": "Cards",
-            "list": "List",
-            "showParaphrase": "Show paraphrase"
+            "submit": "Submit"
         }
     },
     "message": {
@@ -120,41 +94,21 @@
         },
         "import": {
             "success": "The import of {{title}} is finished."
-        },
-        "lcp": {
-            "passphraseError": "Unable to unlock publication {{publicationTitle}}",
-            "renewError": "An error occurred when renewing the LCP license of {{title}}.",
-            "renewSuccess": "The LCP license of {{title}} has been renewed.",
-            "returnError": "An error occurred when returning the LCP license of {{title}}.",
-            "returnSuccess": "The LCP license of {{title}} has been returned"
         }
     },
     "opds": {
         "addForm": {
             "addButton": "Add",
-            "addSentence": "What OPDS feed would you like to add?",
-            "delete": "Delete the feed",
             "name": "Name :",
             "namePlaceholder": "Name",
             "pasteUrl": "paste url of a feed",
             "title": "Add a feed",
-            "update": "Update",
-            "updateSentence": "You can update the fields.",
             "url": "Link :",
             "urlPlaceholder": "Link"
         },
         "addMenu": "Add OPDS feed",
-        "authentication": {
-            "loginButton": "Login",
-            "password": "Password :",
-            "sentence": "Please, log in to access to the contents",
-            "username": "Username :"
-        },
         "back": "Back",
         "breadcrumbRoot": "Catalogs",
-        "download": "Download",
-        "downloadError": "An error occurred while retrieving the feed.",
-        "formError": "Please, fill all the fields",
         "menu": {
             "aboutBook": "About this book",
             "addExtract": "Import the extract",
@@ -162,27 +116,14 @@
             "goBuyBook": "Buy this book",
             "goLoanBook": "Borrow this book",
             "goSubBook": "Subscribe"
-        },
-        "settings": "Settings",
-        "svg": {
-            "opds": "Opds"
         }
     },
     "publication": {
-        "cancelDownloadButton": "Cancel",
-        "canceledDownload": "Download Canceled",
         "deleteButton": "Delete from the library",
-        "downloadButton": "Download",
-        "endDownload": "Download completed",
         "expiredLcp": "This book can't be read because the LCP license has expired.",
-        "failedDownload": "Download Failed",
-        "infoButton": "LCP Informations",
-        "progressDownload": "Downloading",
         "readButton": "Read",
         "renewButton": "Renew",
-        "renewSentence": "Are you sure you want to renew this publication?",
         "returnButton": "Return",
-        "returnSentence": "Are you sure you want to return this publication?",
         "returnedLcp": "This book can't be read because the LCP license has been returned.",
         "revokedLcp": "This book can't be read because the LCP license has been revoked.",
         "seeLess": "See less",
@@ -197,7 +138,6 @@
             "annotations": "Annotations",
             "bookmarks": "Bookmarks",
             "illustrations": "Table of illustrations",
-            "landmarks": "Landmarks",
             "toc": "Table of content"
         },
         "navigation": {
@@ -212,8 +152,6 @@
             "settingsTitle": "settings"
         },
         "settings": {
-            "DefaultFont": "Default font",
-            "accessibility": "Accessibility",
             "column": {
                 "auto": "Automatic",
                 "one": "1 col",
@@ -224,9 +162,7 @@
             },
             "display": "Display",
             "disposition": {
-                "title": "Disposition",
-                "with": "With",
-                "without": "Without"
+                "title": "Disposition"
             },
             "font": "Font",
             "fontSize": "Font size",
@@ -237,36 +173,22 @@
             "lineSpacing": "Line spacing",
             "margin": "Margin",
             "paginated": "Paginated",
-            "right": "Right",
             "scrolled": "Scrollable",
             "spacing": "Spacing",
             "text": "Text",
             "theme": {
-                "create": "Create a theme",
-                "myTheme": "My themes",
                 "name": {
                     "Neutral": "Neutral",
                     "Night": "Night",
                     "Sepia": "Sepia"
                 },
-                "predefined": "Predefined themes",
                 "title": "Theme"
             },
-            "title": "Settings",
             "wordSpacing": "Word spacing"
         },
         "svg": {
-            "alignCenter": "Center align",
-            "alignLeft": "Left align",
-            "alignRight": "Right align",
-            "contentTable": "Content Table",
-            "continue": "Scrolled",
-            "document": "Paginated",
-            "landmark": "Landmark",
             "left": "Left",
-            "night": "Night",
-            "right": "Right",
-            "settings": "Settings"
+            "right": "Right"
         }
     },
     "settings": {
@@ -274,23 +196,6 @@
         "language": {
             "languageChoice": "Language choice"
         },
-        "manageTags": "Manage tags",
         "uiLanguage": "UI language"
-    },
-    "toolbar": {
-        "about": "About",
-        "help": "Help",
-        "news": "What's new?",
-        "svg": {
-            "addEpub": "Add an EPUB",
-            "help": "Help",
-            "news": "News",
-            "opds": "Opds",
-            "others": "Others"
-        },
-        "sync": "Synchronize the library"
-    },
-    "update": {
-        "available": "Update available!"
     }
 }

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -58,6 +58,7 @@
         "alreadyAdd": "It seems that you have already added this publication to your library.",
         "closeModalWindow": "Close this modal window",
         "delete": "Do you really want to delete this publication?",
+        "deleteOpds": "Do you really want to delete this opds feed?",
         "import": "Do you really want to import those EPUB files :",
         "importError": "an error occured, verify your file extension (.epub or .lcpl)",
         "no": "No",
@@ -79,27 +80,81 @@
         "settings": "Settings"
     },
     "library": {
+        "add": "Add to the library",
+        "cancelDownload": "A download canceled.",
+        "endDownload": "A download ended.",
+        "heading": "Library",
         "lcp": {
             "cancel": "Cancel",
             "hint": "(Hint : {{hint}})",
+            "informations": {
+                "close": "Close",
+                "issued": "Creation date:",
+                "provider": "Provider:",
+                "right": {
+                    "copy": "Copy number:",
+                    "end": "End:",
+                    "print": "Print number:",
+                    "start": "Start:",
+                    "title": "Rights"
+                },
+                "title": "LCP Informations",
+                "updated": "Updated:"
+            },
             "password": "Password",
             "sentence": "This publication needs a LCP password to be opened: ",
-            "submit": "Submit"
+            "submit": "Submit",
+            "title": "LCP Verification"
+        },
+        "startDownload": "A download started.",
+        "svg": {
+            "card": "Cards",
+            "list": "List",
+            "showParaphrase": "Show paraphrase"
+        }
+    },
+    "message": {
+        "download": {
+            "start": "The download of {{title}} began.",
+            "success": "The download of {{title}} is finished."
+        },
+        "import": {
+            "success": "The import of {{title}} is finished."
+        },
+        "lcp": {
+            "passphraseError": "Unable to unlock publication {{publicationTitle}}",
+            "renewError": "An error occurred when renewing the LCP license of {{title}}.",
+            "renewSuccess": "The LCP license of {{title}} has been renewed.",
+            "returnError": "An error occurred when returning the LCP license of {{title}}.",
+            "returnSuccess": "The LCP license of {{title}} has been returned"
         }
     },
     "opds": {
         "addForm": {
             "addButton": "Add",
+            "addSentence": "What OPDS feed would you like to add?",
+            "delete": "Delete the feed",
             "name": "Name :",
             "namePlaceholder": "Name",
             "pasteUrl": "paste url of a feed",
             "title": "Add a feed",
+            "update": "Update",
+            "updateSentence": "You can update the fields.",
             "url": "Link :",
             "urlPlaceholder": "Link"
         },
         "addMenu": "Add OPDS feed",
+        "authentication": {
+            "loginButton": "Login",
+            "password": "Password :",
+            "sentence": "Please, log in to access to the contents",
+            "username": "Username :"
+        },
         "back": "Back",
         "breadcrumbRoot": "Catalogs",
+        "download": "Download",
+        "downloadError": "An error occurred while retrieving the feed.",
+        "formError": "Please, fill all the fields",
         "menu": {
             "aboutBook": "About this book",
             "addExtract": "Import the extract",
@@ -107,14 +162,27 @@
             "goBuyBook": "Buy this book",
             "goLoanBook": "Borrow this book",
             "goSubBook": "Subscribe"
+        },
+        "settings": "Settings",
+        "svg": {
+            "opds": "Opds"
         }
     },
     "publication": {
+        "cancelDownloadButton": "Cancel",
+        "canceledDownload": "Download Canceled",
         "deleteButton": "Delete from the library",
+        "downloadButton": "Download",
+        "endDownload": "Download completed",
         "expiredLcp": "This book can't be read because the LCP license has expired.",
+        "failedDownload": "Download Failed",
+        "infoButton": "LCP Informations",
+        "progressDownload": "Downloading",
         "readButton": "Read",
         "renewButton": "Renew",
+        "renewSentence": "Are you sure you want to renew this publication?",
         "returnButton": "Return",
+        "returnSentence": "Are you sure you want to return this publication?",
         "returnedLcp": "This book can't be read because the LCP license has been returned.",
         "revokedLcp": "This book can't be read because the LCP license has been revoked.",
         "seeLess": "See less",
@@ -129,6 +197,7 @@
             "annotations": "Annotations",
             "bookmarks": "Bookmarks",
             "illustrations": "Table of illustrations",
+            "landmarks": "Landmarks",
             "toc": "Table of content"
         },
         "navigation": {
@@ -143,6 +212,8 @@
             "settingsTitle": "settings"
         },
         "settings": {
+            "DefaultFont": "Default font",
+            "accessibility": "Accessibility",
             "column": {
                 "auto": "Automatic",
                 "one": "1 col",
@@ -153,7 +224,9 @@
             },
             "display": "Display",
             "disposition": {
-                "title": "Disposition"
+                "title": "Disposition",
+                "with": "With",
+                "without": "Without"
             },
             "font": "Font",
             "fontSize": "Font size",
@@ -164,22 +237,36 @@
             "lineSpacing": "Line spacing",
             "margin": "Margin",
             "paginated": "Paginated",
+            "right": "Right",
             "scrolled": "Scrollable",
             "spacing": "Spacing",
             "text": "Text",
             "theme": {
+                "create": "Create a theme",
+                "myTheme": "My themes",
                 "name": {
                     "Neutral": "Neutral",
                     "Night": "Night",
                     "Sepia": "Sepia"
                 },
+                "predefined": "Predefined themes",
                 "title": "Theme"
             },
+            "title": "Settings",
             "wordSpacing": "Word spacing"
         },
         "svg": {
+            "alignCenter": "Center align",
+            "alignLeft": "Left align",
+            "alignRight": "Right align",
+            "contentTable": "Content Table",
+            "continue": "Scrolled",
+            "document": "Paginated",
+            "landmark": "Landmark",
             "left": "Left",
-            "right": "Right"
+            "night": "Night",
+            "right": "Right",
+            "settings": "Settings"
         }
     },
     "settings": {
@@ -187,6 +274,23 @@
         "language": {
             "languageChoice": "Language choice"
         },
+        "manageTags": "Manage tags",
         "uiLanguage": "UI language"
+    },
+    "toolbar": {
+        "about": "About",
+        "help": "Help",
+        "news": "What's new?",
+        "svg": {
+            "addEpub": "Add an EPUB",
+            "help": "Help",
+            "news": "News",
+            "opds": "Opds",
+            "others": "Others"
+        },
+        "sync": "Synchronize the library"
+    },
+    "update": {
+        "available": "Update available!"
     }
 }

--- a/src/resources/locales/fr.json
+++ b/src/resources/locales/fr.json
@@ -58,6 +58,7 @@
         "alreadyAdd": "Il semblerais que vous ayez déjà ajouté cette publication à votre catalogue.",
         "closeModalWindow": "Fermer cette fenêtre modale",
         "delete": "Êtes vous sûr de vouloir supprimer cette publication ?",
+        "deleteOpds": "Êtes vous sûr de vouloir supprimer ce flux opds ?",
         "import": "Etes vous sûr de vouloir importer ce(s) fichier(s) EPUB :",
         "importError": "une erreur s'est produite, vérifiez l'extension de votre fichier (.epub ou .lcpl)",
         "no": "Non",
@@ -79,27 +80,81 @@
         "settings": "Préférences"
     },
     "library": {
+        "add": "Ajouter à la bibliothèque",
+        "cancelDownload": "Un téléchargement a été arrété.",
+        "endDownload": "Un téléchargement est terminé.",
+        "heading": "Bibliothèque",
         "lcp": {
             "cancel": "Annuler",
             "hint": "(Indice : {{hint}})",
+            "informations": {
+                "close": "Fermer",
+                "issued": "Date de création :",
+                "provider": "Fournisseur :",
+                "right": {
+                    "copy": "Nombre de copie :",
+                    "end": "Fin :",
+                    "print": "Nombre d'impression :",
+                    "start": "Début :",
+                    "title": "Droits"
+                },
+                "title": "Informations LCP",
+                "updated": "Modification :"
+            },
             "password": "Mot de passe",
             "sentence": "Cette publication a besoin d'un mot de passe : ",
-            "submit": "Valider"
+            "submit": "Valider",
+            "title": "Vérification LCP"
+        },
+        "startDownload": "Un téléchargement a démarré.",
+        "svg": {
+            "card": "Cartes",
+            "list": "Liste",
+            "showParaphrase": "Montrer la paraphrase"
+        }
+    },
+    "message": {
+        "download": {
+            "start": "Le téléchargement de {{title}} a commencé.",
+            "success": "Le téléchargement de {{title}} est terminé."
+        },
+        "import": {
+            "success": "L'import de {{title}} est terminé."
+        },
+        "lcp": {
+            "passphraseError": "Impossible de déverouiller la publication {{publicationTitle}}",
+            "renewError": "Une erreur est survenue lors du renouvellement de {{title}}.",
+            "renewSuccess": "La licence LCP de {{title}} a bien été renouvellée.",
+            "returnError": "Un erreur est survenue lors du retournement de {{title}}.",
+            "returnSuccess": "La license lcp de {{title}} a bien été retorunée."
         }
     },
     "opds": {
         "addForm": {
             "addButton": "Ajouter",
+            "addSentence": "Quel flux OPDS souhaitez vous ajouter ?",
+            "delete": "Supprimer le flux",
             "name": "Nom :",
             "namePlaceholder": "Nom",
             "pasteUrl": "coller l'url d'un flux",
             "title": "Ajouter un flux",
+            "update": "Modifier",
+            "updateSentence": "Vous pouvez mettre les champs à jour.",
             "url": "Adresse :",
             "urlPlaceholder": "Adresse"
         },
         "addMenu": "Ajouter un flux OPDS",
+        "authentication": {
+            "loginButton": "Connexion",
+            "password": "Mot de passe :",
+            "sentence": "Veuillez vous connecter pour acceder au contenu",
+            "username": "Nom d'utilisateur :"
+        },
         "back": "Retour",
         "breadcrumbRoot": "Catalogues",
+        "download": "Télécharger",
+        "downloadError": "Une erreur est survenue lors de la récupération du flux.",
+        "formError": "Veuillez remplir tous les champs",
         "menu": {
             "aboutBook": "Fiche livre",
             "addExtract": "Importer",
@@ -107,14 +162,27 @@
             "goBuyBook": "Aller sur la page d'achat",
             "goLoanBook": "Aller sur la page d'emprunt",
             "goSubBook": "Aller sur la page d'abonnement"
+        },
+        "settings": "Parametre",
+        "svg": {
+            "opds": "Opds"
         }
     },
     "publication": {
+        "cancelDownloadButton": "Annuler",
+        "canceledDownload": "Téléchargement annulé",
         "deleteButton": "Supprimer de la bibliothèque",
+        "downloadButton": "Télécharger",
+        "endDownload": "Téléchargement terminé",
         "expiredLcp": "Ce livre ne peut être lu car la licence lcp a expiré.",
+        "failedDownload": "Téléchargement échoué",
+        "infoButton": "Informations LCP",
+        "progressDownload": "Téléchargement en cours",
         "readButton": "Lire",
         "renewButton": "Renouveler",
+        "renewSentence": "Etes vous sûr de vouloir renouveler cette publication ?",
         "returnButton": "Retourner",
+        "returnSentence": "Etes vous sûr de vouloir retourner cette publication ?",
         "returnedLcp": "Ce livre ne peut être lu car la licence lcp a été retourné.",
         "revokedLcp": "Ce livre ne peut être lu car la licence lcp a été révoqué.",
         "seeLess": "Voir moins",
@@ -129,6 +197,7 @@
             "annotations": "Annotations",
             "bookmarks": "marque pages",
             "illustrations": "Table des Illustrations",
+            "landmarks": "point de repères",
             "toc": "Table des matières "
         },
         "navigation": {
@@ -143,6 +212,8 @@
             "settingsTitle": "préférences"
         },
         "settings": {
+            "DefaultFont": "Police par défaut",
+            "accessibility": "Accessibilité",
             "column": {
                 "auto": "Automatique",
                 "one": "1 col",
@@ -153,7 +224,9 @@
             },
             "display": "Affichage",
             "disposition": {
-                "title": "Disposition"
+                "title": "Disposition",
+                "with": "Avec",
+                "without": "Sans"
             },
             "font": "Police",
             "fontSize": "Taille du texte",
@@ -164,22 +237,36 @@
             "lineSpacing": "Espacement des lignes",
             "margin": "Marge",
             "paginated": "Paginé",
+            "right": "Droite",
             "scrolled": "Défilé",
             "spacing": "Espacement",
             "text": "Texte",
             "theme": {
+                "create": "Créer un thème",
+                "myTheme": "Mes thèmes",
                 "name": {
                     "Neutral": "Neutre",
                     "Night": "Nuit",
                     "Sepia": "Sépia"
                 },
+                "predefined": "Thèmes prédéfinis",
                 "title": "Thème"
             },
+            "title": "Paramètres",
             "wordSpacing": "Espacement des mots"
         },
         "svg": {
+            "alignCenter": "Aligner au centre",
+            "alignLeft": "Aligner à gauche",
+            "alignRight": "Aligner à droite",
+            "contentTable": "Table des matières",
+            "continue": "Défilé",
+            "document": "Paginé",
+            "landmark": "Point de repère",
             "left": "Gauche",
-            "right": "Droite"
+            "night": "Mode Nuit",
+            "right": "Droite",
+            "settings": "Parametres"
         }
     },
     "settings": {
@@ -187,6 +274,23 @@
         "language": {
             "languageChoice": "Choix de la langue"
         },
+        "manageTags": "Gérer mes tags",
         "uiLanguage": "Langue de l'interface"
+    },
+    "toolbar": {
+        "about": "A propos",
+        "help": "Aide",
+        "news": "Quoi de neuf ?",
+        "svg": {
+            "addEpub": "Ajouter un EPUB",
+            "help": "Aide",
+            "news": "Nouvelles",
+            "opds": "Opds",
+            "others": "Autres"
+        },
+        "sync": "Synchroniser la bibliothèque"
+    },
+    "update": {
+        "available": "Nouvelle version !"
     }
 }

--- a/src/resources/locales/fr.json
+++ b/src/resources/locales/fr.json
@@ -58,7 +58,6 @@
         "alreadyAdd": "Il semblerais que vous ayez déjà ajouté cette publication à votre catalogue.",
         "closeModalWindow": "Fermer cette fenêtre modale",
         "delete": "Êtes vous sûr de vouloir supprimer cette publication ?",
-        "deleteOpds": "Êtes vous sûr de vouloir supprimer ce flux opds ?",
         "import": "Etes vous sûr de vouloir importer ce(s) fichier(s) EPUB :",
         "importError": "une erreur s'est produite, vérifiez l'extension de votre fichier (.epub ou .lcpl)",
         "no": "Non",
@@ -80,37 +79,12 @@
         "settings": "Préférences"
     },
     "library": {
-        "add": "Ajouter à la bibliothèque",
-        "cancelDownload": "Un téléchargement a été arrété.",
-        "endDownload": "Un téléchargement est terminé.",
-        "heading": "Bibliothèque",
         "lcp": {
             "cancel": "Annuler",
             "hint": "(Indice : {{hint}})",
-            "informations": {
-                "close": "Fermer",
-                "issued": "Date de création :",
-                "provider": "Fournisseur :",
-                "right": {
-                    "copy": "Nombre de copie :",
-                    "end": "Fin :",
-                    "print": "Nombre d'impression :",
-                    "start": "Début :",
-                    "title": "Droits"
-                },
-                "title": "Informations LCP",
-                "updated": "Modification :"
-            },
             "password": "Mot de passe",
             "sentence": "Cette publication a besoin d'un mot de passe : ",
-            "submit": "Valider",
-            "title": "Vérification LCP"
-        },
-        "startDownload": "Un téléchargement a démarré.",
-        "svg": {
-            "card": "Cartes",
-            "list": "Liste",
-            "showParaphrase": "Montrer la paraphrase"
+            "submit": "Valider"
         }
     },
     "message": {
@@ -120,41 +94,21 @@
         },
         "import": {
             "success": "L'import de {{title}} est terminé."
-        },
-        "lcp": {
-            "passphraseError": "Impossible de déverouiller la publication {{publicationTitle}}",
-            "renewError": "Une erreur est survenue lors du renouvellement de {{title}}.",
-            "renewSuccess": "La licence LCP de {{title}} a bien été renouvellée.",
-            "returnError": "Un erreur est survenue lors du retournement de {{title}}.",
-            "returnSuccess": "La license lcp de {{title}} a bien été retorunée."
         }
     },
     "opds": {
         "addForm": {
             "addButton": "Ajouter",
-            "addSentence": "Quel flux OPDS souhaitez vous ajouter ?",
-            "delete": "Supprimer le flux",
             "name": "Nom :",
             "namePlaceholder": "Nom",
             "pasteUrl": "coller l'url d'un flux",
             "title": "Ajouter un flux",
-            "update": "Modifier",
-            "updateSentence": "Vous pouvez mettre les champs à jour.",
             "url": "Adresse :",
             "urlPlaceholder": "Adresse"
         },
         "addMenu": "Ajouter un flux OPDS",
-        "authentication": {
-            "loginButton": "Connexion",
-            "password": "Mot de passe :",
-            "sentence": "Veuillez vous connecter pour acceder au contenu",
-            "username": "Nom d'utilisateur :"
-        },
         "back": "Retour",
         "breadcrumbRoot": "Catalogues",
-        "download": "Télécharger",
-        "downloadError": "Une erreur est survenue lors de la récupération du flux.",
-        "formError": "Veuillez remplir tous les champs",
         "menu": {
             "aboutBook": "Fiche livre",
             "addExtract": "Importer",
@@ -162,27 +116,14 @@
             "goBuyBook": "Aller sur la page d'achat",
             "goLoanBook": "Aller sur la page d'emprunt",
             "goSubBook": "Aller sur la page d'abonnement"
-        },
-        "settings": "Parametre",
-        "svg": {
-            "opds": "Opds"
         }
     },
     "publication": {
-        "cancelDownloadButton": "Annuler",
-        "canceledDownload": "Téléchargement annulé",
         "deleteButton": "Supprimer de la bibliothèque",
-        "downloadButton": "Télécharger",
-        "endDownload": "Téléchargement terminé",
         "expiredLcp": "Ce livre ne peut être lu car la licence lcp a expiré.",
-        "failedDownload": "Téléchargement échoué",
-        "infoButton": "Informations LCP",
-        "progressDownload": "Téléchargement en cours",
         "readButton": "Lire",
         "renewButton": "Renouveler",
-        "renewSentence": "Etes vous sûr de vouloir renouveler cette publication ?",
         "returnButton": "Retourner",
-        "returnSentence": "Etes vous sûr de vouloir retourner cette publication ?",
         "returnedLcp": "Ce livre ne peut être lu car la licence lcp a été retourné.",
         "revokedLcp": "Ce livre ne peut être lu car la licence lcp a été révoqué.",
         "seeLess": "Voir moins",
@@ -197,7 +138,6 @@
             "annotations": "Annotations",
             "bookmarks": "marque pages",
             "illustrations": "Table des Illustrations",
-            "landmarks": "point de repères",
             "toc": "Table des matières "
         },
         "navigation": {
@@ -212,8 +152,6 @@
             "settingsTitle": "préférences"
         },
         "settings": {
-            "DefaultFont": "Police par défaut",
-            "accessibility": "Accessibilité",
             "column": {
                 "auto": "Automatique",
                 "one": "1 col",
@@ -224,9 +162,7 @@
             },
             "display": "Affichage",
             "disposition": {
-                "title": "Disposition",
-                "with": "Avec",
-                "without": "Sans"
+                "title": "Disposition"
             },
             "font": "Police",
             "fontSize": "Taille du texte",
@@ -237,36 +173,22 @@
             "lineSpacing": "Espacement des lignes",
             "margin": "Marge",
             "paginated": "Paginé",
-            "right": "Droite",
             "scrolled": "Défilé",
             "spacing": "Espacement",
             "text": "Texte",
             "theme": {
-                "create": "Créer un thème",
-                "myTheme": "Mes thèmes",
                 "name": {
                     "Neutral": "Neutre",
                     "Night": "Nuit",
                     "Sepia": "Sépia"
                 },
-                "predefined": "Thèmes prédéfinis",
                 "title": "Thème"
             },
-            "title": "Paramètres",
             "wordSpacing": "Espacement des mots"
         },
         "svg": {
-            "alignCenter": "Aligner au centre",
-            "alignLeft": "Aligner à gauche",
-            "alignRight": "Aligner à droite",
-            "contentTable": "Table des matières",
-            "continue": "Défilé",
-            "document": "Paginé",
-            "landmark": "Point de repère",
             "left": "Gauche",
-            "night": "Mode Nuit",
-            "right": "Droite",
-            "settings": "Parametres"
+            "right": "Droite"
         }
     },
     "settings": {
@@ -274,23 +196,6 @@
         "language": {
             "languageChoice": "Choix de la langue"
         },
-        "manageTags": "Gérer mes tags",
         "uiLanguage": "Langue de l'interface"
-    },
-    "toolbar": {
-        "about": "A propos",
-        "help": "Aide",
-        "news": "Quoi de neuf ?",
-        "svg": {
-            "addEpub": "Ajouter un EPUB",
-            "help": "Aide",
-            "news": "Nouvelles",
-            "opds": "Opds",
-            "others": "Autres"
-        },
-        "sync": "Synchroniser la bibliothèque"
-    },
-    "update": {
-        "available": "Nouvelle version !"
     }
 }

--- a/src/typings/en.translation.d.ts
+++ b/src/typings/en.translation.d.ts
@@ -167,6 +167,18 @@ declare namespace typed_i18n {
   (_: "library.lcp.password", __?: {}): string;
   (_: "library.lcp.sentence", __?: {}): string;
   (_: "library.lcp.submit", __?: {}): string;
+  (_: "message", __?: {}): {
+  readonly "download": {
+    readonly "start": string,
+    readonly "success": string
+  },
+  readonly "import": { readonly "success": string }
+};
+  (_: "message.download", __?: {}): { readonly "start": string, readonly "success": string };
+  (_: "message.download.start", __?: {}): string;
+  (_: "message.download.success", __?: {}): string;
+  (_: "message.import", __?: {}): { readonly "success": string };
+  (_: "message.import.success", __?: {}): string;
   (_: "opds", __?: {}): {
   readonly "addForm": {
     readonly "addButton": string,


### PR DESCRIPTION
Fixes https://github.com/readium/readium-desktop/issues/526

Follow-up to PR https://github.com/readium/readium-desktop/pull/516/

Original locales (sorted, but not yet trimmed):

https://raw.githubusercontent.com/readium/readium-desktop/1352b0170b7a622f01bc4bab6e8c727421c31dad/src/resources/locales/de.json
https://raw.githubusercontent.com/readium/readium-desktop/1352b0170b7a622f01bc4bab6e8c727421c31dad/src/resources/locales/en.json
https://raw.githubusercontent.com/readium/readium-desktop/1352b0170b7a622f01bc4bab6e8c727421c31dad/src/resources/locales/fr.json

(https://github.com/readium/readium-desktop/commit/1352b0170b7a622f01bc4bab6e8c727421c31dad is just before https://github.com/readium/readium-desktop/commit/23fe2a2a9f65e42df225dcbc30f2f7054ece7f69 )

See:

https://github.com/readium/readium-desktop/commits/23fe2a2a9f65e42df225dcbc30f2f7054ece7f69
and:
https://github.com/readium/readium-desktop/commits/23fe2a2a9f65e42df225dcbc30f2f7054ece7f69/src/resources/locales/en.json