### PR TITLE
[fix] pass reject boolean into react props when api return a rejection

### DIFF
--- a/src/renderer/components/utils/api.tsx
+++ b/src/renderer/components/utils/api.tsx
@@ -20,6 +20,7 @@ export interface ApiOperationDefinition {
     methodId: string;
     callProp?: string;
     resultProp?: string;
+    resultIsRejectProp?: string;
     buildRequestData?: any;
     onLoad?: boolean; // Load in component did mount, default true
 }
@@ -140,6 +141,10 @@ export function withApi(WrappedComponent: any, queryConfig: ApiConfig) {
                 const result = state.api.data[operationRequest.id].result;
                 const resultProp = operationRequest.definition.resultProp;
                 operationResults[resultProp] = result;
+
+                const resultIsReject = state.api.data[operationRequest.id].resultIsReject;
+                const resultIsRejectProp = operationRequest.definition.resultIsRejectProp;
+                operationResults[resultIsRejectProp] = resultIsReject;
             }
         }
 

--- a/src/renderer/redux/reducers/api.ts
+++ b/src/renderer/redux/reducers/api.ts
@@ -20,7 +20,7 @@ export function apiReducer(
     state: ApiState<any> = initialState,
     action: ApiAction,
 ) {
-    const resultIsReject = action.type === ActionType.Error ? true : false;
+    const resultIsReject = action.type === ActionType.Error;
 
     switch (action.type) {
         case ActionType.Error:

--- a/src/renderer/redux/reducers/api.ts
+++ b/src/renderer/redux/reducers/api.ts
@@ -8,23 +8,29 @@
 import * as moment from "moment";
 
 import { ActionType, ApiAction } from "readium-desktop/common/redux/actions/api";
+import { ApiState } from "readium-desktop/renderer/redux/states/api";
 
-const initialState: any = {
+const initialState: ApiState<any> = {
     data: {},
     lastSuccess: null,
 };
 
 // The api reducer.
 export function apiReducer(
-    state: any = initialState,
+    state: ApiState<any> = initialState,
     action: ApiAction,
 ) {
+    const resultIsReject = action.type === ActionType.Error ? true : false;
+
     switch (action.type) {
+        case ActionType.Error:
         case ActionType.Success:
             const data = state.data;
             const now = moment.now();
+            // Why here is it not immutable ?
             data[action.meta.api.requestId] = {
                 result: action.payload,
+                resultIsReject,
                 requestId: action.meta.api.requestId,
                 moduleId: action.meta.api.moduleId,
                 methodId: action.meta.api.methodId,

--- a/src/renderer/redux/states/api.ts
+++ b/src/renderer/redux/states/api.ts
@@ -15,14 +15,15 @@ interface PageState<T> {
 
 export interface ApiDataResponse<T> {
     result: (T | PageState<T>);
+    resultIsReject?: boolean;
     date: number;
     requestId: string;
-    module: string;
     methodId: string;
+    moduleId: string;
 }
 
-export interface ApiDataState {
-    [id: string]: ApiDataResponse<any>;
+export interface ApiDataState<T> {
+    [id: string]: ApiDataResponse<T>;
 }
 
 export interface ApiLastSuccess {
@@ -30,7 +31,7 @@ export interface ApiLastSuccess {
     date: number;
 }
 
-export interface ApiState {
+export interface ApiState<T> {
     lastSuccess: ApiLastSuccess;
-    data: ApiDataState;
+    data: ApiDataState<T>;
 }

--- a/src/renderer/redux/states/index.ts
+++ b/src/renderer/redux/states/index.ts
@@ -33,7 +33,7 @@ export interface RootState {
     opds: OpdsState;
     reader: ReaderState;
     update: UpdateState;
-    api: ApiState;
+    api: ApiState<any>;
     dialog: DialogState;
     router: RouterState;
     import: ImportState;


### PR DESCRIPTION
@danielweck as we discussed

Action ERROR handled like SUCCESS allow to pass ERROR string data like a SUCCESS string data and to flag an error boolean into resultIsRejectProp