### PR TITLE
fix(i10n): fix fr label

### DIFF
--- a/src/resources/locales/fr.json
+++ b/src/resources/locales/fr.json
@@ -139,13 +139,13 @@
         },
         "marks": {
             "annotations": "Annotations",
-            "bookmarks": "marque pages",
+            "bookmarks": "Marque-pages",
             "illustrations": "Table des Illustrations",
             "toc": "Table des matières "
         },
         "navigation": {
             "backHomeTitle": "retour à la bibliothèque",
-            "bookmarkTitle": "marque page",
+            "bookmarkTitle": "marque-page",
             "detachWindowTitle": "détacher la fenêtre",
             "fullscreenTitle": "mode plein écran",
             "infoTitle": "informations",


### PR DESCRIPTION
Simple replacement of "marque page" by "marque-page" and addition of a capital letter for "Marque-pages" as used as a title in the navigation tab. 