### PR TITLE
Fixed R2 package imports (aliases), fixes #657

### DIFF
--- a/src/common/views/publication.ts
+++ b/src/common/views/publication.ts
@@ -5,7 +5,7 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { Metadata } from "r2-shared-js/dist/es6-es2015/src/models/metadata";
+import { Metadata } from "@r2-shared-js/models/metadata";
 
 export interface CoverView {
     url: string;

--- a/src/main/services/catalog.ts
+++ b/src/main/services/catalog.ts
@@ -7,55 +7,37 @@
 
 import * as debug_ from "debug";
 import * as fs from "fs";
+import { inject, injectable } from "inversify";
 import * as path from "path";
-
+import { RandomCustomCovers } from "readium-desktop/common/models/custom-cover";
+import { Download } from "readium-desktop/common/models/download";
+import { Publication } from "readium-desktop/common/models/publication";
+import { closeReaderFromPublication } from "readium-desktop/common/redux/actions/reader";
+import { convertMultiLangStringToString } from "readium-desktop/common/utils";
+import { httpGet } from "readium-desktop/common/utils/http";
+import { PublicationView } from "readium-desktop/common/views/publication";
+import { PublicationApi } from "readium-desktop/main/api/publication";
+import {
+    PublicationDocument, THttpGetPublicationDocument,
+} from "readium-desktop/main/db/document/publication";
+import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
+import { container } from "readium-desktop/main/di";
+import { OpdsParsingError } from "readium-desktop/main/exceptions/opds";
+import { PublicationStorage } from "readium-desktop/main/storage/publication-storage";
+import { Store } from "redux";
 import { JSON as TAJSON } from "ta-json-x";
-
+import * as uuid from "uuid";
 import * as xmldom from "xmldom";
 
-import * as uuid from "uuid";
-
-import {
-    convertOpds1ToOpds2_EntryToPublication,
-} from "@r2-opds-js/opds/converter";
-
-import { inject, injectable} from "inversify";
-
-import { RandomCustomCovers } from "readium-desktop/common/models/custom-cover";
-import { Publication } from "readium-desktop/common/models/publication";
-
+import { convertOpds1ToOpds2_EntryToPublication } from "@r2-opds-js/opds/converter";
+import { Entry } from "@r2-opds-js/opds/opds1/opds-entry";
+import { OPDSPublication } from "@r2-opds-js/opds/opds2/opds2-publication";
 import { Publication as Epub } from "@r2-shared-js/models/publication";
 import { EpubParsePromise } from "@r2-shared-js/parser/epub";
-
 import { XML } from "@r2-utils-js/_utils/xml-js-mapper";
-
-import { Entry } from "@r2-opds-js/opds/opds1/opds-entry";
-
-import { PublicationDocument, THttpGetPublicationDocument } from "readium-desktop/main/db/document/publication";
-import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
-
-import { PublicationStorage } from "readium-desktop/main/storage/publication-storage";
-
-import { Download } from "readium-desktop/common/models/download";
-
-import { httpGet } from "readium-desktop/common/utils/http";
-import { OpdsParsingError } from "readium-desktop/main/exceptions/opds";
 
 import { Downloader } from "./downloader";
 import { LcpManager } from "./lcp";
-
-import {
-    convertMultiLangStringToString,
-} from "readium-desktop/common/utils";
-
-import { OPDSPublication } from "r2-opds-js/dist/es6-es2015/src/opds/opds2/opds2-publication";
-import { PublicationView } from "readium-desktop/common/views/publication";
-
-import { container } from "readium-desktop/main/di";
-import { Store } from "redux";
-
-import { closeReaderFromPublication } from "readium-desktop/common/redux/actions/reader";
-import { PublicationApi } from "readium-desktop/main/api/publication";
 
 // Logger
 const debug = debug_("readium-desktop:main#services/catalog");

--- a/src/renderer/components/reader/Reader.tsx
+++ b/src/renderer/components/reader/Reader.tsx
@@ -6,75 +6,45 @@
 // ==LICENSE-END==
 
 import * as path from "path";
+import * as queryString from "query-string";
 import * as React from "react";
-
-import {
-    ReaderConfig as ReadiumCSS,
-} from "readium-desktop/common/models/reader";
-
-import {
-    colCountEnum,
-    IReadiumCSS,
-    readiumCSSDefaults,
-    textAlignEnum,
-} from "@r2-navigator-js/electron/common/readium-css-settings";
-import {
-    getCurrentReadingLocation,
-    handleLinkLocator,
-    handleLinkUrl,
-    installNavigatorDOM,
-    isLocatorVisible,
-    LocatorExtended,
-    navLeftOrRight,
-    readiumCssOnOff,
-    setEpubReadingSystemInfo,
-    setReadingLocationSaver,
-    setReadiumCssJsonGetter,
-} from "@r2-navigator-js/electron/renderer/index";
-
-import {
-    convertCustomSchemeToHttpUrl,
-    READIUM2_ELECTRON_HTTP_PROTOCOL,
-} from "@r2-navigator-js/electron/common/sessions";
-import {
-    _NODE_MODULE_RELATIVE_URL,
-    _PACKAGING,
-    _RENDERER_READER_BASE_URL,
-} from "readium-desktop/preprocessor-directives";
-
-import {
-    IEventPayload_R2_EVENT_READIUMCSS,
-} from "@r2-navigator-js/electron/common/events";
-import { getURLQueryParams } from "@r2-navigator-js/electron/renderer/common/querystring";
-import { Locator } from "@r2-shared-js/models/locator";
-import { Publication as R2Publication } from "r2-shared-js/dist/es6-es2015/src/models/publication";
+import { DialogType } from "readium-desktop/common/models/dialog";
+import { Publication } from "readium-desktop/common/models/publication";
+import { ReaderConfig as ReadiumCSS } from "readium-desktop/common/models/reader";
 import { readerActions } from "readium-desktop/common/redux/actions";
+import * as dialogActions from "readium-desktop/common/redux/actions/dialog";
 import { setLocale } from "readium-desktop/common/redux/actions/i18n";
 import { Translator } from "readium-desktop/common/services/translator";
-import { _APP_VERSION } from "readium-desktop/preprocessor-directives";
+import { LocatorView } from "readium-desktop/common/views/locator";
+import {
+    _APP_NAME, _APP_VERSION, _NODE_MODULE_RELATIVE_URL, _PACKAGING, _RENDERER_READER_BASE_URL,
+} from "readium-desktop/preprocessor-directives";
+import * as styles from "readium-desktop/renderer/assets/styles/reader-app.css";
 import ReaderFooter from "readium-desktop/renderer/components/reader/ReaderFooter";
 import ReaderHeader from "readium-desktop/renderer/components/reader/ReaderHeader";
+import { withApi } from "readium-desktop/renderer/components/utils/api";
 import { container, lazyInject } from "readium-desktop/renderer/di";
 import { RootState } from "readium-desktop/renderer/redux/states";
 import { Store } from "redux";
 import { JSON as TAJSON } from "ta-json-x";
 
-import { DialogType } from "readium-desktop/common/models/dialog";
-import * as dialogActions from "readium-desktop/common/redux/actions/dialog";
+import { IEventPayload_R2_EVENT_READIUMCSS } from "@r2-navigator-js/electron/common/events";
+import {
+    colCountEnum, IReadiumCSS, readiumCSSDefaults, textAlignEnum,
+} from "@r2-navigator-js/electron/common/readium-css-settings";
+import {
+    convertCustomSchemeToHttpUrl, READIUM2_ELECTRON_HTTP_PROTOCOL,
+} from "@r2-navigator-js/electron/common/sessions";
+import { getURLQueryParams } from "@r2-navigator-js/electron/renderer/common/querystring";
+import {
+    getCurrentReadingLocation, handleLinkLocator, handleLinkUrl, installNavigatorDOM,
+    isLocatorVisible, LocatorExtended, navLeftOrRight, readiumCssOnOff, setEpubReadingSystemInfo,
+    setReadingLocationSaver, setReadiumCssJsonGetter,
+} from "@r2-navigator-js/electron/renderer/index";
+import { Locator } from "@r2-shared-js/models/locator";
+import { Publication as R2Publication } from "@r2-shared-js/models/publication";
 
 import optionsValues from "./options-values";
-
-import { withApi } from "readium-desktop/renderer/components/utils/api";
-
-import * as queryString from "query-string";
-
-import { LocatorView } from "readium-desktop/common/views/locator";
-
-import * as styles from "readium-desktop/renderer/assets/styles/reader-app.css";
-
-import { Publication } from "readium-desktop/common/models/publication";
-
-import { _APP_NAME } from "readium-desktop/preprocessor-directives";
 
 // import { registerProtocol } from "@r2-navigator-js/electron/renderer/common/protocol";
 // registerProtocol();

--- a/src/renderer/components/reader/ReaderFooter.tsx
+++ b/src/renderer/components/reader/ReaderFooter.tsx
@@ -6,17 +6,14 @@
 // ==LICENSE-END==
 
 import * as React from "react";
-
 import * as ArrowRightIcon from "readium-desktop/renderer/assets/icons/baseline-arrow_forward_ios-24px.svg";
 import * as ArrowLeftIcon from "readium-desktop/renderer/assets/icons/baseline-arrow_left_ios-24px.svg";
-
-import { Publication } from "r2-shared-js/dist/es6-es2015/src/models/publication";
-
+import * as styles from "readium-desktop/renderer/assets/styles/reader-app.css";
 import SVG from "readium-desktop/renderer/components/utils/SVG";
 
 import { LocatorExtended } from "@r2-navigator-js/electron/renderer/index";
+import { Publication } from "@r2-shared-js/models/publication";
 
-import * as styles from "readium-desktop/renderer/assets/styles/reader-app.css";
 import { TranslatorProps, withTranslator } from "../utils/translator";
 
 interface Props extends TranslatorProps {

--- a/src/renderer/components/reader/ReaderMenu.tsx
+++ b/src/renderer/components/reader/ReaderMenu.tsx
@@ -5,10 +5,8 @@
 // that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 // ==LICENSE-END==
 
-import { Publication as R2Publication } from "@r2-shared-js/models/publication";
 import classnames from "classnames";
 import * as queryString from "query-string";
-import { Link } from "r2-shared-js/dist/es6-es2015/src/models/publication-link";
 import * as React from "react";
 import { LocatorView } from "readium-desktop/common/views/locator";
 import * as DeleteIcon from "readium-desktop/renderer/assets/icons/baseline-close-24px.svg";
@@ -16,7 +14,13 @@ import * as EditIcon from "readium-desktop/renderer/assets/icons/baseline-edit-2
 import * as styles from "readium-desktop/renderer/assets/styles/reader-app.css";
 import { withApi } from "readium-desktop/renderer/components/utils/api";
 import SVG from "readium-desktop/renderer/components/utils/SVG";
-import { TranslatorProps, withTranslator } from "readium-desktop/renderer/components/utils/translator";
+import {
+    TranslatorProps, withTranslator,
+} from "readium-desktop/renderer/components/utils/translator";
+
+import { Publication as R2Publication } from "@r2-shared-js/models/publication";
+import { Link } from "@r2-shared-js/models/publication-link";
+
 import SideMenu from "./sideMenu/SideMenu";
 import { SectionData } from "./sideMenu/sideMenuData";
 import UpdateBookmarkForm from "./UpdateBookmarkForm";


### PR DESCRIPTION
Note that TypeScript imports are automatically sorted with this Visual Studio Code extension:
https://github.com/SoominHan/import-sorter

(default settings with only "double quote" and "trailing comma when multiline" modified, to comply with the project linter configuration)