### PR TITLE
[FIX] replace msi with nsis in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "win": {
       "target": [
         "appx",
-        "msi"
+        "nsis"
       ],
       "icon": "dist/assets/icons/icon.ico"
     },


### PR DESCRIPTION
It appears that msi do not register any key in windows registry. The registry key to associate extension with executable launch doesn't works with msi installer but only with nsis.

With nsis,  thorium is added like default software with extension epub, epub3.
