### PR TITLE
Fix typo

### DIFF
--- a/src/resources/locales/de.json
+++ b/src/resources/locales/de.json
@@ -69,7 +69,7 @@
         "yes": "Ja"
     },
     "header": {
-        "allBooks": "Alle bücher",
+        "allBooks": "Alle Bücher",
         "books": "Meine Bücher",
         "catalogs": "Kataloge",
         "gridTitle": "Buchumschläge in einem Raster präsentieren",


### PR DESCRIPTION
"Bücher" needs to be uppercase, as every noun in German