### PR TITLE
renamed incorrectly-named DB doc fields (resources object)

### DIFF
--- a/src/main/converter/publication.ts
+++ b/src/main/converter/publication.ts
@@ -17,7 +17,7 @@ import { Publication as Epub } from "@r2-shared-js/models/publication";
 @injectable()
 export class PublicationViewConverter {
     public convertDocumentToView(document: PublicationDocument): PublicationView {
-        const b64ParsedPublication = document.resources.filePublication;
+        const b64ParsedPublication = document.resources.r2PublicationBase64;
         const jsonParsedPublication = Buffer
             .from(b64ParsedPublication, "base64")
             .toString("utf-8");

--- a/src/main/db/document/publication.ts
+++ b/src/main/db/document/publication.ts
@@ -13,8 +13,8 @@ import { Timestampable } from "readium-desktop/common/models/timestampable";
 import { IHttpGetResult } from "readium-desktop/common/utils/http";
 
 interface Resources {
-    filePublication: string;
-    opdsPublication: string;
+    r2PublicationBase64: string;
+    r2OpdsPublicationBase64: string;
 }
 
 export interface PublicationDocument extends Identifiable, Timestampable {

--- a/src/main/db/repository/publication.ts
+++ b/src/main/db/repository/publication.ts
@@ -106,7 +106,11 @@ export class PublicationRepository extends BaseRepository<PublicationDocument> {
             {},
             super.convertToMinimalDocument(dbDoc),
             {
-                resources: dbDoc.resources,
+                resources: dbDoc.resources ? {
+                    // legacy names fallback
+                    r2PublicationBase64: dbDoc.resources.r2PublicationBase64 || dbDoc.resources.filePublication,
+                    r2OpdsPublicationBase64: dbDoc.resources.r2OpdsPublicationBase64 || dbDoc.resources.opdsPublication,
+                } : undefined,
                 opdsPublication: dbDoc.opdsPublication,
                 title: ((typeof dbDoc.title !== "string") ? convertMultiLangStringToString(dbDoc.title) : dbDoc.title),
                 tags: dbDoc.tags,

--- a/src/main/services/catalog.ts
+++ b/src/main/services/catalog.ts
@@ -220,8 +220,8 @@ export class CatalogService {
             publicationDocument,
             {
                 resources: {
-                    filePublication: publicationDocument.resources.filePublication,
-                    opdsPublication: b64OpdsPublication,
+                    r2PublicationBase64: publicationDocument.resources.r2PublicationBase64,
+                    r2OpdsPublicationBase64: b64OpdsPublication,
                 },
                 tags,
             },
@@ -270,7 +270,7 @@ export class CatalogService {
             origPub,
             {
                 resources: {
-                    filePublication: b64ParsedPublication,
+                    r2PublicationBase64: b64ParsedPublication,
                 },
             },
         );
@@ -355,8 +355,8 @@ export class CatalogService {
         const pubDocument = {
             identifier: uuid.v4(),
             resources: {
-                filePublication: b64ParsedPublication,
-                opdsPublication: null,
+                r2PublicationBase64: b64ParsedPublication,
+                r2OpdsPublicationBase64: null,
             },
             title: convertMultiLangStringToString(parsedPublication.Metadata.Title),
             tags: [],

--- a/src/main/services/lcp.ts
+++ b/src/main/services/lcp.ts
@@ -126,8 +126,8 @@ export class LcpManager {
             publicationDocument,
             {
                 resources: {
-                    filePublication: b64ParsedPublication,
-                    opdsPublication: publicationDocument.resources.opdsPublication,
+                    r2PublicationBase64: b64ParsedPublication,
+                    r2OpdsPublicationBase64: publicationDocument.resources.r2OpdsPublicationBase64,
                 },
                 lcp: lcpInfo,
             },


### PR DESCRIPTION
This is in preparation for a larger refactor of types and consistent object names (a prerequisite to the LCP/LSD PR https://github.com/readium/readium-desktop/pull/795 ).
Note that this change handles the legacy names in a backwards-compatible manner.