### PR TITLE
Simplification of the DB TypeScript type system

### DIFF
--- a/src/main/db/document/publication.ts
+++ b/src/main/db/document/publication.ts
@@ -21,7 +21,6 @@ export interface Resources {
 
 export interface PublicationDocument extends Identifiable, Timestampable {
     resources: Resources;
-    // opdsPublication: any; // TODO any?! OPDSPublication? seems unused!
     title: string;
     tags?: string[];
     files?: File[];

--- a/src/main/db/repository/config.ts
+++ b/src/main/db/repository/config.ts
@@ -7,28 +7,23 @@
 
 import { injectable } from "inversify";
 import * as PouchDB from "pouchdb-core";
-import { Identifiable } from "readium-desktop/common/models/identifiable";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
 import { ConfigDocument } from "readium-desktop/main/db/document/config";
 
-import { BaseRepository, DatabaseContentType } from "./base";
-
-export interface DatabaseContentTypeConfig<T> extends DatabaseContentType, ConfigDocument<T> {
-}
+import { BaseRepository, ExcludeTimestampableAndIdentifiable } from "./base";
 
 @injectable()
-export class ConfigRepository<T> extends BaseRepository<ConfigDocument<T>, DatabaseContentTypeConfig<T>> {
-    public constructor(db: PouchDB.Database<DatabaseContentTypeConfig<T>>) {
+export class ConfigRepository<T> extends BaseRepository<ConfigDocument<T>> {
+    public constructor(db: PouchDB.Database<ConfigDocument<T>>) {
         super(db, "config");
     }
 
-    protected convertToDocument(dbDoc: PouchDB.Core.Document<DatabaseContentTypeConfig<T>>): ConfigDocument<T> {
+    protected convertToDocument(dbDoc: PouchDB.Core.Document<ConfigDocument<T>>): ConfigDocument<T> {
         return Object.assign(
             {},
             super.convertToMinimalDocument(dbDoc),
             {
                 value: dbDoc.value,
-            } as Omit<ConfigDocument<T>, keyof Timestampable | keyof Identifiable>,
+            } as ExcludeTimestampableAndIdentifiable<ConfigDocument<T>>,
         );
     }
 }

--- a/src/main/db/repository/lcp-secret.ts
+++ b/src/main/db/repository/lcp-secret.ts
@@ -7,22 +7,16 @@
 
 import { injectable } from "inversify";
 import * as PouchDB from "pouchdb-core";
-import { Identifiable } from "readium-desktop/common/models/identifiable";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
 import { LcpSecretDocument } from "readium-desktop/main/db/document/lcp-secret";
 
-import { BaseRepository, DatabaseContentType } from "./base";
+import { BaseRepository, ExcludeTimestampableAndIdentifiable } from "./base";
 
 const PUBLICATION_IDENTIFIER_INDEX = "publication_identifier";
 
-export interface DatabaseContentTypeLcpSecret extends DatabaseContentType, LcpSecretDocument {
-}
-
 @injectable()
-export class LcpSecretRepository extends BaseRepository<LcpSecretDocument, DatabaseContentTypeLcpSecret> {
-    public constructor(db: PouchDB.Database<DatabaseContentTypeLcpSecret>) {
+export class LcpSecretRepository extends BaseRepository<LcpSecretDocument> {
+    public constructor(db: PouchDB.Database<LcpSecretDocument>) {
 
-        // See DatabaseContentTypeLcpSecret
         const indexes = [
             {
                 fields: ["publicationIdentifier"], // LcpSecretDocument
@@ -38,14 +32,14 @@ export class LcpSecretRepository extends BaseRepository<LcpSecretDocument, Datab
         });
     }
 
-    protected convertToDocument(dbDoc: PouchDB.Core.Document<DatabaseContentTypeLcpSecret>): LcpSecretDocument {
+    protected convertToDocument(dbDoc: PouchDB.Core.Document<LcpSecretDocument>): LcpSecretDocument {
         return Object.assign(
             {},
             super.convertToMinimalDocument(dbDoc),
             {
                 publicationIdentifier: dbDoc.publicationIdentifier,
                 secret: dbDoc.secret,
-            } as Omit<LcpSecretDocument, keyof Timestampable | keyof Identifiable>,
+            } as ExcludeTimestampableAndIdentifiable<LcpSecretDocument>,
         );
     }
 }

--- a/src/main/db/repository/locator.ts
+++ b/src/main/db/repository/locator.ts
@@ -7,25 +7,19 @@
 
 import { injectable } from "inversify";
 import * as PouchDB from "pouchdb-core";
-import { Identifiable } from "readium-desktop/common/models/identifiable";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
 import { LocatorDocument } from "readium-desktop/main/db/document/locator";
 
-import { BaseRepository, DatabaseContentType } from "./base";
+import { BaseRepository, ExcludeTimestampableAndIdentifiable } from "./base";
 
 const PUBLICATION_INDEX = "publication_index";
 const LOCATOR_TYPE_INDEX = "locator_type_index";
 const CREATED_AT_INDEX = "created_at_index";
 const UPDATED_AT_INDEX = "updatded_at_index";
 
-export interface DatabaseContentTypeLocator extends DatabaseContentType, LocatorDocument {
-}
-
 @injectable()
-export class LocatorRepository extends BaseRepository<LocatorDocument, DatabaseContentTypeLocator> {
-    public constructor(db: PouchDB.Database<DatabaseContentTypeLocator>) {
+export class LocatorRepository extends BaseRepository<LocatorDocument> {
+    public constructor(db: PouchDB.Database<LocatorDocument>) {
 
-        // See DatabaseContentTypeLocator
         const indexes = [
             {
                 fields: ["createdAt"], // Timestampable
@@ -73,7 +67,7 @@ export class LocatorRepository extends BaseRepository<LocatorDocument, DatabaseC
         });
     }
 
-    protected convertToDocument(dbDoc: PouchDB.Core.Document<DatabaseContentTypeLocator>): LocatorDocument {
+    protected convertToDocument(dbDoc: PouchDB.Core.Document<LocatorDocument>): LocatorDocument {
         return Object.assign(
             {},
             super.convertToMinimalDocument(dbDoc),
@@ -82,7 +76,7 @@ export class LocatorRepository extends BaseRepository<LocatorDocument, DatabaseC
                 locatorType: dbDoc.locatorType,
                 publicationIdentifier: dbDoc.publicationIdentifier,
                 name: dbDoc.name,
-            } as Omit<LocatorDocument, keyof Timestampable | keyof Identifiable>,
+            } as ExcludeTimestampableAndIdentifiable<LocatorDocument>,
         );
     }
 }

--- a/src/main/db/repository/opds.ts
+++ b/src/main/db/repository/opds.ts
@@ -7,29 +7,24 @@
 
 import { injectable } from "inversify";
 import * as PouchDB from "pouchdb-core";
-import { Identifiable } from "readium-desktop/common/models/identifiable";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
 import { OpdsFeedDocument } from "readium-desktop/main/db/document/opds";
 
-import { BaseRepository, DatabaseContentType } from "./base";
-
-export interface DatabaseContentTypeOpds extends DatabaseContentType, OpdsFeedDocument {
-}
+import { BaseRepository, ExcludeTimestampableAndIdentifiable } from "./base";
 
 @injectable()
-export class OpdsFeedRepository extends BaseRepository<OpdsFeedDocument, DatabaseContentTypeOpds> {
-    public constructor(db: PouchDB.Database<DatabaseContentTypeOpds>) {
+export class OpdsFeedRepository extends BaseRepository<OpdsFeedDocument> {
+    public constructor(db: PouchDB.Database<OpdsFeedDocument>) {
         super(db, "opds-feed");
     }
 
-    protected convertToDocument(dbDoc: PouchDB.Core.Document<DatabaseContentTypeOpds>): OpdsFeedDocument {
+    protected convertToDocument(dbDoc: PouchDB.Core.Document<OpdsFeedDocument>): OpdsFeedDocument {
         return Object.assign(
             {},
             super.convertToMinimalDocument(dbDoc),
             {
                 title: dbDoc.title,
                 url: dbDoc.url,
-            } as Omit<OpdsFeedDocument, keyof Timestampable | keyof Identifiable>,
+            } as ExcludeTimestampableAndIdentifiable<OpdsFeedDocument>,
         );
     }
 }

--- a/src/main/di.ts
+++ b/src/main/di.ts
@@ -21,21 +21,16 @@ import { IPublicationApi, PublicationApi } from "readium-desktop/main/api/public
 import { LocatorViewConverter } from "readium-desktop/main/converter/locator";
 import { OpdsFeedViewConverter } from "readium-desktop/main/converter/opds";
 import { PublicationViewConverter } from "readium-desktop/main/converter/publication";
-import {
-    ConfigRepository, DatabaseContentTypeConfig,
-} from "readium-desktop/main/db/repository/config";
-import {
-    DatabaseContentTypeLcpSecret, LcpSecretRepository,
-} from "readium-desktop/main/db/repository/lcp-secret";
-import {
-    DatabaseContentTypeLocator, LocatorRepository,
-} from "readium-desktop/main/db/repository/locator";
-import {
-    DatabaseContentTypeOpds, OpdsFeedRepository,
-} from "readium-desktop/main/db/repository/opds";
-import {
-    DatabaseContentTypePublication, PublicationRepository,
-} from "readium-desktop/main/db/repository/publication";
+import { ConfigDocument } from "readium-desktop/main/db/document/config";
+import { LcpSecretDocument } from "readium-desktop/main/db/document/lcp-secret";
+import { LocatorDocument } from "readium-desktop/main/db/document/locator";
+import { OpdsFeedDocument } from "readium-desktop/main/db/document/opds";
+import { PublicationDocument } from "readium-desktop/main/db/document/publication";
+import { ConfigRepository } from "readium-desktop/main/db/repository/config";
+import { LcpSecretRepository } from "readium-desktop/main/db/repository/lcp-secret";
+import { LocatorRepository } from "readium-desktop/main/db/repository/locator";
+import { OpdsFeedRepository } from "readium-desktop/main/db/repository/opds";
+import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
 import { diSymbolTable } from "readium-desktop/main/diSymbolTable";
 import { initStore } from "readium-desktop/main/redux/store/memory";
 import { CatalogService } from "readium-desktop/main/services/catalog";
@@ -107,35 +102,35 @@ const dbOpts = {
 };
 
 // Publication db
-const publicationDb = new PouchDB<DatabaseContentTypePublication>(
+const publicationDb = new PouchDB<PublicationDocument>(
     path.join(rootDbPath, "publication"),
     dbOpts,
 );
 const publicationRepository = new PublicationRepository(publicationDb);
 
 // OPDS db
-const opdsDb = new PouchDB<DatabaseContentTypeOpds>(
+const opdsDb = new PouchDB<OpdsFeedDocument>(
     path.join(rootDbPath, "opds"),
     dbOpts,
 );
 const opdsFeedRepository = new OpdsFeedRepository(opdsDb);
 
 // Config db
-const configDb = new PouchDB<DatabaseContentTypeConfig<any>>(
+const configDb = new PouchDB<ConfigDocument<any>>(
     path.join(rootDbPath, "config"),
     dbOpts,
 );
 const configRepository = new ConfigRepository(configDb);
 
 // Locator db
-const locatorDb = new PouchDB<DatabaseContentTypeLocator>(
+const locatorDb = new PouchDB<LocatorDocument>(
     path.join(rootDbPath, "locator"),
     dbOpts,
 );
 const locatorRepository = new LocatorRepository(locatorDb);
 
 // Lcp secret db
-const lcpSecretDb = new PouchDB<DatabaseContentTypeLcpSecret>(
+const lcpSecretDb = new PouchDB<LcpSecretDocument>(
     path.join(rootDbPath, "lcp-secret"),
     dbOpts,
 );

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -275,7 +275,6 @@ function* closeReader(reader: Reader, gotoLibrary: boolean) {
 }
 
 const READER_CONFIG_ID = "reader";
-type ConfigDocumentTypeWithoutTimestampable = Omit<ConfigDocument<ReaderConfig>, keyof Timestampable>;
 
 export function* readerConfigSetRequestWatcher(): SagaIterator {
     while (true) {
@@ -283,7 +282,7 @@ export function* readerConfigSetRequestWatcher(): SagaIterator {
         const action = yield* takeTyped(readerActions.configSetRequest.build);
 
         const configValue = action.payload.config;
-        const config: ConfigDocumentTypeWithoutTimestampable = {
+        const config: Omit<ConfigDocument<ReaderConfig>, keyof Timestampable> = {
             identifier: READER_CONFIG_ID,
             value: configValue,
         };

--- a/src/main/services/catalog.ts
+++ b/src/main/services/catalog.ts
@@ -430,9 +430,6 @@ export class CatalogService {
 
             lcp: null, // updated below via lcpManager.updateDocumentLcpLsdBase64Resources()
             lcpRightsCopies: 0,
-
-            // OPDSPublication? seems unused!
-            // opdsPublication: undefined,
         };
         this.lcpManager.updateDocumentLcpLsdBase64Resources(pubDocument, r2Publication.LCP);
 

--- a/src/main/services/lcp.ts
+++ b/src/main/services/lcp.ts
@@ -133,7 +133,7 @@ export class LcpManager {
             debug("processStatusDocument LCP updated.");
         }
 
-        const newPublicationDocument: PublicationDocument = Object.assign(
+        const newPublicationDocument: PublicationDocumentWithoutTimestampable = Object.assign(
             {},
             publicationDocument,
             {
@@ -146,7 +146,7 @@ export class LcpManager {
     }
 
     public updateDocumentLcpLsdBase64Resources(
-        publicationDocument: PublicationDocument | PublicationDocumentWithoutTimestampable,
+        publicationDocument: PublicationDocumentWithoutTimestampable,
         r2Lcp: LCP,
     ) {
         if (!publicationDocument.resources) {
@@ -263,7 +263,7 @@ export class LcpManager {
             publicationDocument.identifier,
         );
 
-        const newPublicationDocument: PublicationDocument = Object.assign(
+        const newPublicationDocument: PublicationDocumentWithoutTimestampable = Object.assign(
             {},
             publicationDocument,
             {
@@ -342,7 +342,7 @@ export class LcpManager {
                 const epubPath = this.publicationStorage.getPublicationEpubPath(
                     publicationDocument.identifier,
                 );
-                const newPublicationDocument = Object.assign(
+                const newPublicationDocument: PublicationDocumentWithoutTimestampable = Object.assign(
                     {},
                     publicationDocument,
                     {
@@ -416,7 +416,7 @@ export class LcpManager {
                 const epubPath = this.publicationStorage.getPublicationEpubPath(
                     publicationDocument.identifier,
                 );
-                const newPublicationDocument = Object.assign(
+                const newPublicationDocument: PublicationDocumentWithoutTimestampable = Object.assign(
                     {},
                     publicationDocument,
                     {

--- a/test/main/db/repository/lcp-secret.test.ts
+++ b/test/main/db/repository/lcp-secret.test.ts
@@ -1,41 +1,46 @@
 import "reflect-metadata";
 
 import * as moment from "moment";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
+import { LcpSecretDocument } from "readium-desktop/main/db/document/lcp-secret";
 import { NotFoundError } from "readium-desktop/main/db/exceptions";
 import {
-    DatabaseContentTypeLcpSecret, LcpSecretRepository,
-} from "readium-desktop/main/db/repository/lcp-secret";
+    ExcludeTimestampableWithPartialIdentifiable,
+} from "readium-desktop/main/db/repository/base";
+import { LcpSecretRepository } from "readium-desktop/main/db/repository/lcp-secret";
 import { clearDatabase, createDatabase } from "test/main/db/utils";
 
 let repository: LcpSecretRepository | null = null;
-let db: PouchDB.Database<DatabaseContentTypeLcpSecret> | null = null;
+let db: PouchDB.Database<LcpSecretDocument> | null = null;
 const now = moment.now();
 
 const dbDocIdentifier1 = "lcp-secret-1";
+const dbDocIdentifier1Internal = `lcp_secret_${dbDocIdentifier1}`;
 const dbPubIdentifier1 = "pub-1";
-const dbDoc1: DatabaseContentTypeLcpSecret & PouchDB.Core.IdMeta = {
+const secret1 = "secret-1";
+const dbDoc1: PouchDB.Core.PutDocument<LcpSecretDocument> = {
     identifier: dbDocIdentifier1,
-    _id: "lcp_secret_" + dbDocIdentifier1,
+    _id: dbDocIdentifier1Internal,
     publicationIdentifier: dbPubIdentifier1,
-    secret: "secret-1",
+    secret: secret1,
     createdAt: now,
     updatedAt: now,
 };
 
 const dbDocIdentifier2 = "lcp-secret-2";
+const dbDocIdentifier2Internal = `lcp_secret_${dbDocIdentifier2}`;
 const dbPubIdentifier2 = "pub-2";
-const dbDoc2: DatabaseContentTypeLcpSecret & PouchDB.Core.IdMeta = {
+const secret2 = "secret-2";
+const dbDoc2: PouchDB.Core.PutDocument<LcpSecretDocument> = {
     identifier: dbDocIdentifier2,
-    _id: "lcp_secret_" + dbDocIdentifier2,
+    _id: dbDocIdentifier2Internal,
     publicationIdentifier: dbPubIdentifier2,
-    secret: "secret-2",
+    secret: secret2,
     createdAt: now,
     updatedAt: now,
 };
 
 beforeEach(async () => {
-    db = createDatabase<DatabaseContentTypeLcpSecret>();
+    db = createDatabase<LcpSecretDocument>();
     repository = new LcpSecretRepository(db);
 
     // Create data
@@ -48,7 +53,7 @@ afterEach(async () => {
         return;
     }
     repository = null;
-    await clearDatabase<DatabaseContentTypeLcpSecret>(db);
+    await clearDatabase<LcpSecretDocument>(db);
 });
 
 test("repository.findAll", async () => {
@@ -63,12 +68,12 @@ test("repository.findByPublicationIdentifier - found", async () => {
     if (!repository) {
         return;
     }
-    const result = await repository.findByPublicationIdentifier("pub-1");
+    const result = await repository.findByPublicationIdentifier(dbPubIdentifier1);
     expect(result.length).toBe(1);
     const lcpSecret = result[0];
-    expect(lcpSecret.identifier).toBe("lcp-secret-1");
-    expect(lcpSecret.publicationIdentifier).toBe("pub-1");
-    expect(lcpSecret.secret).toBe("secret-1");
+    expect(lcpSecret.identifier).toBe(dbDocIdentifier1);
+    expect(lcpSecret.publicationIdentifier).toBe(dbPubIdentifier1);
+    expect(lcpSecret.secret).toBe(secret1);
 });
 
 test("repository.findByPublicationIdentifier - not found", async () => {
@@ -83,10 +88,10 @@ test("repository.get - found", async () => {
     if (!repository) {
         return;
     }
-    const result = await repository.get("lcp-secret-1");
-    expect(result.identifier).toBe("lcp-secret-1");
-    expect(result.publicationIdentifier).toBe("pub-1");
-    expect(result.secret).toBe("secret-1");
+    const result = await repository.get(dbDocIdentifier1);
+    expect(result.identifier).toBe(dbDocIdentifier1);
+    expect(result.publicationIdentifier).toBe(dbPubIdentifier1);
+    expect(result.secret).toBe(secret1);
 });
 
 test("repository.get - not found", async () => {
@@ -106,15 +111,15 @@ test("repository.save create", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypeLcpSecret, keyof Timestampable> & PouchDB.Core.IdMeta = {
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<LcpSecretDocument> = { //  & PouchDB.Core.IdMeta
         identifier: "new-lcp-secret",
-        _id: "lcp_secret_new-lcp-secret",
+        // _id: "lcp_secret_new-lcp-secret",
         publicationIdentifier: dbPubIdentifier2,
         secret: "secret-3",
     };
     const result = await repository.save(dbDoc);
     expect(result.identifier).toBe("new-lcp-secret");
-    expect(result.publicationIdentifier).toBe("pub-2");
+    expect(result.publicationIdentifier).toBe(dbPubIdentifier2);
     expect(result.secret).toBe("secret-3");
     expect(result.createdAt).toBeDefined();
     expect(result.updatedAt).toBeDefined();
@@ -125,14 +130,14 @@ test("repository.save update", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypeLcpSecret, keyof Timestampable> = {
-        identifier: "lcp-secret-1",
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<LcpSecretDocument> = {
+        identifier: dbDocIdentifier1,
         publicationIdentifier: dbPubIdentifier1,
         secret: "updated-secret",
     };
     const result = await repository.save(dbDoc);
-    expect(result.identifier).toBe("lcp-secret-1");
-    expect(result.publicationIdentifier).toBe("pub-1");
+    expect(result.identifier).toBe(dbDocIdentifier1);
+    expect(result.publicationIdentifier).toBe(dbPubIdentifier1);
     expect(result.secret).toBe("updated-secret");
     expect(result.createdAt).toBeDefined();
     expect(result.updatedAt).toBeDefined();
@@ -143,13 +148,13 @@ test("repository.delete", async () => {
     if (!db || !repository) {
         return;
     }
-    const result = await db.get("lcp_secret_lcp-secret-1") as any;
-    expect(result.identifier).toBe("lcp-secret-1");
+    const result = await db.get(dbDocIdentifier1Internal) as any;
+    expect(result.identifier).toBe(dbDocIdentifier1);
 
     // Delete publication 1
-    await repository.delete("lcp-secret-1");
+    await repository.delete(dbDocIdentifier1);
     try {
-        await db.get("lcp_secret_lcp-secret-1");
+        await db.get(dbDocIdentifier1Internal);
     } catch (e) {
         expect(e.message).toBe("missing");
     }

--- a/test/main/db/repository/locator.test.ts
+++ b/test/main/db/repository/locator.test.ts
@@ -2,26 +2,31 @@ import "reflect-metadata";
 
 import * as moment from "moment";
 import { LocatorType } from "readium-desktop/common/models/locator";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
+import { LocatorDocument } from "readium-desktop/main/db/document/locator";
 import { NotFoundError } from "readium-desktop/main/db/exceptions";
 import {
-    DatabaseContentTypeLocator, LocatorRepository,
-} from "readium-desktop/main/db/repository/locator";
+    ExcludeTimestampableWithPartialIdentifiable,
+} from "readium-desktop/main/db/repository/base";
+import { LocatorRepository } from "readium-desktop/main/db/repository/locator";
 import { clearDatabase, createDatabase } from "test/main/db/utils";
 
 let repository: LocatorRepository | null = null;
-let db: PouchDB.Database<DatabaseContentTypeLocator> | null = null;
+let db: PouchDB.Database<LocatorDocument> | null = null;
 const now = moment.now();
 
 const dbDocIdentifier1 = "bookmark-1";
-const dbDoc1: DatabaseContentTypeLocator & PouchDB.Core.IdMeta = {
+const dbDocIdentifier1Internal = `locator_${dbDocIdentifier1}`;
+const publicationIdentifier1 = "pub-1";
+const title1 = "Bookmark 1";
+const href1 = "/spines/spine-1";
+const dbDoc1: PouchDB.Core.PutDocument<LocatorDocument> = {
     identifier: dbDocIdentifier1,
-    _id: "locator_" + dbDocIdentifier1,
+    _id: dbDocIdentifier1Internal,
     locatorType: LocatorType.Bookmark,
-    publicationIdentifier: "pub-1",
+    publicationIdentifier: publicationIdentifier1,
     locator: {
-        href: "/spines/spine-1",
-        title: "Bookmark 1",
+        href: href1,
+        title: title1,
         locations: {
             position: 12,
         },
@@ -31,11 +36,13 @@ const dbDoc1: DatabaseContentTypeLocator & PouchDB.Core.IdMeta = {
 };
 
 const dbDocIdentifier2 = "bookmark-2";
-const dbDoc2: DatabaseContentTypeLocator & PouchDB.Core.IdMeta = {
+const dbDocIdentifier2Internal = `locator_${dbDocIdentifier2}`;
+const publicationIdentifier2 = "pub-2";
+const dbDoc2: PouchDB.Core.PutDocument<LocatorDocument> = {
     identifier: dbDocIdentifier2,
-    _id: "locator_" + dbDocIdentifier2,
+    _id: dbDocIdentifier2Internal,
     locatorType: LocatorType.Bookmark,
-    publicationIdentifier: "pub-2",
+    publicationIdentifier: publicationIdentifier2,
     locator: {
         href: "/spines/spine-2",
         title: "Bookmark 2",
@@ -48,7 +55,7 @@ const dbDoc2: DatabaseContentTypeLocator & PouchDB.Core.IdMeta = {
 };
 
 beforeEach(async () => {
-    db = createDatabase<DatabaseContentTypeLocator>();
+    db = createDatabase<LocatorDocument>();
     repository = new LocatorRepository(db);
 
     // Create data
@@ -61,7 +68,7 @@ afterEach(async () => {
         return;
     }
     repository = null;
-    await clearDatabase<DatabaseContentTypeLocator>(db);
+    await clearDatabase<LocatorDocument>(db);
 });
 
 test("repository.findAll", async () => {
@@ -76,14 +83,14 @@ test("repository.findByPublicationIdentifer - found", async () => {
     if (!repository) {
         return;
     }
-    const result = await repository.findByPublicationIdentifier("pub-1");
+    const result = await repository.findByPublicationIdentifier(publicationIdentifier1);
     expect(result.length).toBe(1);
     const locator = result[0];
-    expect(locator.identifier).toBe("bookmark-1");
+    expect(locator.identifier).toBe(dbDocIdentifier1);
     expect(locator.locatorType).toBe(LocatorType.Bookmark);
-    expect(locator.publicationIdentifier).toBe("pub-1");
-    expect(locator.locator.href).toBe("/spines/spine-1");
-    expect(locator.locator.title).toBe("Bookmark 1");
+    expect(locator.publicationIdentifier).toBe(publicationIdentifier1);
+    expect(locator.locator.href).toBe(href1);
+    expect(locator.locator.title).toBe(title1);
 });
 test("repository.findByPublicationIdentifer - not found", async () => {
     if (!repository) {
@@ -114,15 +121,15 @@ test("repository.findByPublicationIdentifer - found", async () => {
         return;
     }
     const result = await repository.findByPublicationIdentifierAndLocatorType(
-        "pub-1", LocatorType.Bookmark,
+        publicationIdentifier1, LocatorType.Bookmark,
     );
     expect(result.length).toBe(1);
     const locator = result[0];
-    expect(locator.identifier).toBe("bookmark-1");
+    expect(locator.identifier).toBe(dbDocIdentifier1);
     expect(locator.locatorType).toBe(LocatorType.Bookmark);
-    expect(locator.publicationIdentifier).toBe("pub-1");
-    expect(locator.locator.href).toBe("/spines/spine-1");
-    expect(locator.locator.title).toBe("Bookmark 1");
+    expect(locator.publicationIdentifier).toBe(publicationIdentifier1);
+    expect(locator.locator.href).toBe(href1);
+    expect(locator.locator.title).toBe(title1);
 });
 
 test("repository.findByPublicationIdentifer - not found", async () => {
@@ -130,7 +137,7 @@ test("repository.findByPublicationIdentifer - not found", async () => {
         return;
     }
     const result = await repository.findByPublicationIdentifierAndLocatorType(
-        "pub-1", LocatorType.LastReadingLocation,
+        publicationIdentifier1, LocatorType.LastReadingLocation,
     );
     expect(result.length).toBe(0);
 });
@@ -139,12 +146,12 @@ test("repository.get - found", async () => {
     if (!repository) {
         return;
     }
-    const result = await repository.get("bookmark-1");
-    expect(result.identifier).toBe("bookmark-1");
+    const result = await repository.get(dbDocIdentifier1);
+    expect(result.identifier).toBe(dbDocIdentifier1);
     expect(result.locatorType).toBe(LocatorType.Bookmark);
-    expect(result.publicationIdentifier).toBe("pub-1");
-    expect(result.locator.href).toBe("/spines/spine-1");
-    expect(result.locator.title).toBe("Bookmark 1");
+    expect(result.publicationIdentifier).toBe(publicationIdentifier1);
+    expect(result.locator.href).toBe(href1);
+    expect(result.locator.title).toBe(title1);
     expect(result.locator.locations.position).toBe(12);
 });
 
@@ -165,10 +172,10 @@ test("repository.save create", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypeLocator, keyof Timestampable> = {
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<LocatorDocument> = {
         identifier: "new-bookmark",
         locatorType: LocatorType.LastReadingLocation,
-        publicationIdentifier: "pub-1",
+        publicationIdentifier: publicationIdentifier1,
         locator: {
             href: "/spines/spine-3",
             locations: {
@@ -179,7 +186,7 @@ test("repository.save create", async () => {
     const result = await repository.save(dbDoc);
     expect(result.identifier).toBe("new-bookmark");
     expect(result.locatorType).toBe(LocatorType.LastReadingLocation);
-    expect(result.publicationIdentifier).toBe("pub-1");
+    expect(result.publicationIdentifier).toBe(publicationIdentifier1);
     expect(result.locator.href).toBe("/spines/spine-3");
     expect(result.locator.locations.position).toBe(138);
     expect(result.createdAt).toBeDefined();
@@ -191,12 +198,12 @@ test("repository.save update", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypeLocator, keyof Timestampable> = {
-        identifier: "bookmark-1",
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<LocatorDocument> = {
+        identifier: dbDocIdentifier1,
         locatorType: LocatorType.Bookmark,
-        publicationIdentifier: "pub-1",
+        publicationIdentifier: publicationIdentifier1,
         locator: {
-            href: "/spines/spine-1",
+            href: href1,
             title: "New bookmark",
             locations: {
                 position: 12,
@@ -204,10 +211,10 @@ test("repository.save update", async () => {
         },
     };
     const result = await repository.save(dbDoc);
-    expect(result.identifier).toBe("bookmark-1");
+    expect(result.identifier).toBe(dbDocIdentifier1);
     expect(result.locatorType).toBe(LocatorType.Bookmark);
-    expect(result.publicationIdentifier).toBe("pub-1");
-    expect(result.locator.href).toBe("/spines/spine-1");
+    expect(result.publicationIdentifier).toBe(publicationIdentifier1);
+    expect(result.locator.href).toBe(href1);
     expect(result.locator.title).toBe("New bookmark");
     expect(result.locator.locations.position).toBe(12);
     expect(result.createdAt).toBeDefined();
@@ -219,13 +226,13 @@ test("repository.delete", async () => {
     if (!db || !repository) {
         return;
     }
-    const result = await db.get("locator_bookmark-1") as any;
-    expect(result.identifier).toBe("bookmark-1");
+    const result = await db.get(dbDocIdentifier1Internal) as any;
+    expect(result.identifier).toBe(dbDocIdentifier1);
 
     // Delete locator 1
-    await repository.delete("bookmark-1");
+    await repository.delete(dbDocIdentifier1);
     try {
-        await db.get("bookmark-1");
+        await db.get(dbDocIdentifier1);
     } catch (e) {
         expect(e.message).toBe("missing");
     }

--- a/test/main/db/repository/opds.test.ts
+++ b/test/main/db/repository/opds.test.ts
@@ -1,31 +1,36 @@
 import "reflect-metadata";
 
 import * as moment from "moment";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
+import { OpdsFeedDocument } from "readium-desktop/main/db/document/opds";
 import { NotFoundError } from "readium-desktop/main/db/exceptions";
 import {
-    DatabaseContentTypeOpds, OpdsFeedRepository,
-} from "readium-desktop/main/db/repository/opds";
+    ExcludeTimestampableWithPartialIdentifiable,
+} from "readium-desktop/main/db/repository/base";
+import { OpdsFeedRepository } from "readium-desktop/main/db/repository/opds";
 import { clearDatabase, createDatabase } from "test/main/db/utils";
 
 let repository: OpdsFeedRepository | null = null;
-let db: PouchDB.Database<DatabaseContentTypeOpds> | null = null;
+let db: PouchDB.Database<OpdsFeedDocument> | null = null;
 const now = moment.now();
 
 const dbDocIdentifier1 = "feed-1";
-const dbDoc1: DatabaseContentTypeOpds & PouchDB.Core.IdMeta = {
+const dbDocIdentifier1Internal = `opds-feed_${dbDocIdentifier1}`;
+const title1 = "Feed 1";
+const url1 = "https://feed.org/1";
+const dbDoc1: PouchDB.Core.PutDocument<OpdsFeedDocument> = {
     identifier: dbDocIdentifier1,
-    _id: "opds-feed_" + dbDocIdentifier1,
-    title: "Feed 1",
-    url: "https://feed.org/1",
+    _id: dbDocIdentifier1Internal,
+    title: title1,
+    url: url1,
     createdAt: now,
     updatedAt: now,
 };
 
 const dbDocIdentifier2 = "feed-2";
-const dbDoc2: DatabaseContentTypeOpds & PouchDB.Core.IdMeta = {
+const dbDocIdentifier2Internal = `opds-feed_${dbDocIdentifier2}`;
+const dbDoc2: PouchDB.Core.PutDocument<OpdsFeedDocument> = {
     identifier: dbDocIdentifier2,
-    _id: "opds-feed_" + dbDocIdentifier2,
+    _id: dbDocIdentifier2Internal,
     title: "Feed 2",
     url: "https://feed.org/2",
     createdAt: now,
@@ -33,7 +38,7 @@ const dbDoc2: DatabaseContentTypeOpds & PouchDB.Core.IdMeta = {
 };
 
 beforeEach(async () => {
-    db = createDatabase<DatabaseContentTypeOpds>();
+    db = createDatabase<OpdsFeedDocument>();
     repository = new OpdsFeedRepository(db);
 
     // Create data
@@ -46,7 +51,7 @@ afterEach(async () => {
         return;
     }
     repository = null;
-    await clearDatabase<DatabaseContentTypeOpds>(db);
+    await clearDatabase<OpdsFeedDocument>(db);
 });
 
 test("repository.findAll", async () => {
@@ -61,10 +66,10 @@ test("repository.get - found", async () => {
     if (!repository) {
         return;
     }
-    const result = await repository.get("feed-1");
-    expect(result.identifier).toBe("feed-1");
-    expect(result.title).toBe("Feed 1");
-    expect(result.url).toBe("https://feed.org/1");
+    const result = await repository.get(dbDocIdentifier1);
+    expect(result.identifier).toBe(dbDocIdentifier1);
+    expect(result.title).toBe(title1);
+    expect(result.url).toBe(url1);
 });
 
 test("repository.get - not found", async () => {
@@ -84,7 +89,7 @@ test("repository.save create", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypeOpds, keyof Timestampable> = {
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<OpdsFeedDocument> = {
         identifier: "new-feed",
         title: "New feed",
         url: "https://feed.org/new",
@@ -102,13 +107,13 @@ test("repository.save update", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypeOpds, keyof Timestampable> = {
-        identifier: "feed-1",
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<OpdsFeedDocument> = {
+        identifier: dbDocIdentifier1,
         title: "New feed",
         url: "https://feed.org/new",
     };
     const result = await repository.save(dbDoc);
-    expect(result.identifier).toBe("feed-1");
+    expect(result.identifier).toBe(dbDocIdentifier1);
     expect(result.title).toBe("New feed");
     expect(result.url).toBe("https://feed.org/new");
     expect(result.createdAt).toBeDefined();
@@ -120,14 +125,14 @@ test("repository.delete", async () => {
     if (!db || !repository) {
         return;
     }
-    const result = await db.get("opds-feed_feed-1") as any;
-    expect(result.identifier).toBe("feed-1");
+    const result = await db.get(dbDocIdentifier1Internal) as any;
+    expect(result.identifier).toBe(dbDocIdentifier1);
 
     // Delete feed 1
-    await repository.delete("feed-1");
+    await repository.delete(dbDocIdentifier1);
     try {
         // tslint:disable-next-line:no-unused-expression
-        await db.get("opds-feed_feed-1") as any;
+        await db.get(dbDocIdentifier1Internal) as any;
     } catch (e) {
         expect(e.message).toBe("missing");
     }

--- a/test/main/db/repository/publication.test.ts
+++ b/test/main/db/repository/publication.test.ts
@@ -1,23 +1,28 @@
 import "reflect-metadata";
 
 import * as moment from "moment";
-import { Timestampable } from "readium-desktop/common/models/timestampable";
+import { PublicationDocument } from "readium-desktop/main/db/document/publication";
 import { NotFoundError } from "readium-desktop/main/db/exceptions";
 import {
-    DatabaseContentTypePublication, PublicationRepository,
-} from "readium-desktop/main/db/repository/publication";
+    ExcludeTimestampableWithPartialIdentifiable,
+} from "readium-desktop/main/db/repository/base";
+import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
 import { clearDatabase, createDatabase } from "test/main/db/utils";
 
 let repository: PublicationRepository | null = null;
-let db: PouchDB.Database<DatabaseContentTypePublication> | null = null;
+let db: PouchDB.Database<PublicationDocument> | null = null;
 const now = moment.now();
 
 const dbDocIdentifier1 = "pub-1";
-const dbDoc1: DatabaseContentTypePublication & PouchDB.Core.IdMeta = {
+const dbDocIdentifier1Internal = `publication_${dbDocIdentifier1}`;
+const title1 = "Publication 1";
+const tag1 = "science";
+const tag2 = "computer";
+const dbDoc1: PouchDB.Core.PutDocument<PublicationDocument> = {
     identifier: dbDocIdentifier1,
-    _id: "publication_" + dbDocIdentifier1,
-    title: "Publication 1",
-    tags: ["science", "computer"],
+    _id: dbDocIdentifier1Internal,
+    title: title1,
+    tags: [tag1, tag2],
     files: [],
     coverFile: null,
     customCover: null,
@@ -33,11 +38,14 @@ const dbDoc1: DatabaseContentTypePublication & PouchDB.Core.IdMeta = {
 };
 
 const dbDocIdentifier2 = "pub-2";
-const dbDoc2: DatabaseContentTypePublication & PouchDB.Core.IdMeta = {
+const dbDocIdentifier2Internal = `publication_${dbDocIdentifier2}`;
+const title2 = "Publication 2";
+const tag3 = "node";
+const dbDoc2: PouchDB.Core.PutDocument<PublicationDocument> = {
     identifier: dbDocIdentifier2,
-    _id: "publication_" + dbDocIdentifier2,
-    title: "Publication 2",
-    tags: ["node", "computer"],
+    _id: dbDocIdentifier2Internal,
+    title: title2,
+    tags: [tag3, tag2],
     files: [],
     coverFile: null,
     customCover: null,
@@ -53,7 +61,7 @@ const dbDoc2: DatabaseContentTypePublication & PouchDB.Core.IdMeta = {
 };
 
 beforeEach(async () => {
-    db = createDatabase<DatabaseContentTypePublication>();
+    db = createDatabase<PublicationDocument>();
     repository = new PublicationRepository(db);
 
     // Create data
@@ -66,7 +74,7 @@ afterEach(async () => {
         return;
     }
     repository = null;
-    await clearDatabase<DatabaseContentTypePublication>(db);
+    await clearDatabase<PublicationDocument>(db);
 });
 
 test("repository.findAll", async () => {
@@ -97,29 +105,29 @@ test("repository.find sort by createdAt", async () => {
         selector: {},
     });
     expect(result.length).toBe(2);
-    expect(result[0].identifier).toBe("pub-2");
-    expect(result[1].identifier).toBe("pub-1");
+    expect(result[0].identifier).toBe(dbDocIdentifier2);
+    expect(result[1].identifier).toBe(dbDocIdentifier1);
 });
 
 test("repository.findByTag - found", async () => {
     if (!repository) {
         return;
     }
-    let result = await repository.findByTag("computer");
+    let result = await repository.findByTag(tag2);
     expect(result.length).toBe(2);
 
-    result = await repository.findByTag("node");
+    result = await repository.findByTag(tag3);
     expect(result.length).toBe(1);
 
     const pub = result[0];
-    expect(pub.identifier).toBe("pub-2");
-    expect(pub.title).toBe("Publication 2");
+    expect(pub.identifier).toBe(dbDocIdentifier2);
+    expect(pub.title).toBe(title2);
     expect(pub.tags).toBeDefined();
     if (pub.tags) {
         expect(pub.tags.length).toBe(2);
     }
-    expect(pub.tags).toContain("computer");
-    expect(pub.tags).toContain("node");
+    expect(pub.tags).toContain(tag2);
+    expect(pub.tags).toContain(tag3);
 });
 
 test("repository.findByTag - not found", async () => {
@@ -134,7 +142,7 @@ test("repository.findByTitle - found", async () => {
     if (!repository) {
         return;
     }
-    const result = await repository.findByTitle("Publication 1");
+    const result = await repository.findByTitle(title1);
     expect(result.length).toBe(1);
 });
 
@@ -153,7 +161,7 @@ test("repository.searchByTitle - found", async () => {
     let result = await repository.searchByTitle("publication");
     expect(result.length).toBe(2);
 
-    result = await repository.searchByTitle("publication 1");
+    result = await repository.searchByTitle(title1);
     expect(result.length).toBe(1);
 });
 
@@ -163,24 +171,24 @@ test("repository.getAllTags", async () => {
     }
     const tags = await repository.getAllTags();
     expect(tags.length).toBe(3);
-    expect(tags).toContain("computer");
-    expect(tags).toContain("node");
-    expect(tags).toContain("science");
+    expect(tags).toContain(tag2);
+    expect(tags).toContain(tag3);
+    expect(tags).toContain(tag1);
 });
 
 test("repository.get - found", async () => {
     if (!repository) {
         return;
     }
-    const result = await repository.get("pub-1");
-    expect(result.identifier).toBe("pub-1");
-    expect(result.title).toBe("Publication 1");
+    const result = await repository.get(dbDocIdentifier1);
+    expect(result.identifier).toBe(dbDocIdentifier1);
+    expect(result.title).toBe(title1);
     expect(result.tags).toBeDefined();
     if (result.tags) {
         expect(result.tags.length).toBe(2);
     }
-    expect(result.tags).toContain("computer");
-    expect(result.tags).toContain("science");
+    expect(result.tags).toContain(tag2);
+    expect(result.tags).toContain(tag1);
 });
 
 test("repository.get - not found", async () => {
@@ -200,7 +208,7 @@ test("repository.save create", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypePublication, keyof Timestampable> = {
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<PublicationDocument> = {
         identifier: "new-publication",
         title: "New publication",
         tags: ["scifi"],
@@ -232,10 +240,10 @@ test("repository.save update", async () => {
     if (!repository) {
         return;
     }
-    const dbDoc: Omit<DatabaseContentTypePublication, keyof Timestampable> = {
-        identifier: "pub-1",
-        title: "Publication 1",
-        tags: ["computer"],
+    const dbDoc: ExcludeTimestampableWithPartialIdentifiable<PublicationDocument> = {
+        identifier: dbDocIdentifier1,
+        title: title1,
+        tags: [tag2],
         files: [],
         coverFile: null,
         customCover: null,
@@ -248,13 +256,13 @@ test("repository.save update", async () => {
         hash: "",
     };
     const result = await repository.save(dbDoc);
-    expect(result.identifier).toBe("pub-1");
-    expect(result.title).toBe("Publication 1");
+    expect(result.identifier).toBe(dbDocIdentifier1);
+    expect(result.title).toBe(title1);
     expect(result.tags).toBeDefined();
     if (result.tags) {
         expect(result.tags.length).toBe(1);
     }
-    expect(result.tags).toContain("computer");
+    expect(result.tags).toContain(tag2);
     expect(result.createdAt).toBeDefined();
     expect(result.updatedAt).toBeDefined();
     expect(result.createdAt < result.updatedAt).toBeTruthy();
@@ -264,13 +272,13 @@ test("repository.delete", async () => {
     if (!db || !repository) {
         return;
     }
-    const result = await db.get("publication_pub-1");
-    expect(result.identifier).toBe("pub-1");
+    const result = await db.get(dbDocIdentifier1Internal);
+    expect(result.identifier).toBe(dbDocIdentifier1);
 
     // Delete publication 1
-    await repository.delete("pub-1");
+    await repository.delete(dbDocIdentifier1);
     try {
-        await db.get("pub-1");
+        await db.get(dbDocIdentifier1);
     } catch (e) {
         expect(e.message).toBe("missing");
     }


### PR DESCRIPTION
This PR follows https://github.com/readium/readium-desktop/pull/857
to rationalize the type system further, by handling the bi-directional conversion between DB document (PouchDB) and the TypeScript models used in application logic.