### PR TITLE
Windows registry code cleanup to clarify intent, avoid breaking encapsulation of Electron BrowserWindow internals ("id" was used as indexing for array-like list)

### DIFF
--- a/src/common/models/win.ts
+++ b/src/common/models/win.ts
@@ -19,4 +19,5 @@ export interface AppWindow extends Identifiable {
     type: AppWindowType;
     win: BrowserWindow;
     onWindowMoveResize: IOnWindowMoveResize;
+    registerIndex: number;
 }

--- a/src/common/rectangle/window.ts
+++ b/src/common/rectangle/window.ts
@@ -12,7 +12,7 @@ import { ConfigRepository } from "readium-desktop/main/db/repository/config";
 import { diMainGet } from "readium-desktop/main/di";
 import { debounce } from "readium-desktop/utils/debounce";
 
-import { AppWindow, AppWindowType } from "../models/win";
+import { AppWindowType } from "../models/win";
 
 // Logger
 const debug = debug_("readium-desktop:common:rectangle:window");
@@ -43,28 +43,26 @@ export const savedWindowsRectangle = async (rectangle: Rectangle) => {
 };
 const debounceSavedWindowsRectangle = debounce<t_savedWindowsRectangle>(savedWindowsRectangle, 500);
 
-export const getWindowsRectangle = async (WinType?: AppWindowType): Promise<Rectangle> => {
+export const getWindowPositionRectangle = async (winType?: AppWindowType): Promise<Rectangle> => {
 
     try {
         const winRegistry = diMainGet("win-registry");
-
-        // WinDictionary = BrowserWindows indexed by number
-        // (the number is Electron.BrowserWindow.id)
-        const windowsDict = winRegistry.getWindows();
-
-        // generic / template type does not work because dictionary not indexed by string, but by number
-        // const windows = Object.values<AppWindow>(windowsDict);
-        const windows = Object.values(windowsDict) as AppWindow[];
+        const appWindows = winRegistry.getAllWindows();
 
         const displayArea = screen.getPrimaryDisplay().workAreaSize;
-        if (WinType !== AppWindowType.Library && windows.length > 1) {
-            const rectangle = windows.pop().win.getBounds();
+
+        if (winType !== AppWindowType.Library && // is reader window
+            appWindows.length > 1) { // there are already reader windows
+
+            const rectangle = appWindows[appWindows.length - 1].win.getBounds();
             rectangle.x += 100;
             rectangle.x %= displayArea.width - rectangle.width;
             rectangle.y += 100;
             rectangle.y %= displayArea.height - rectangle.height;
             return rectangle;
-        } else {
+
+        } else { // winType === AppWindowType.Library || appWindows.length == 1
+
             const configRepository: ConfigRepository<Rectangle> = diMainGet("config-repository");
             let rectangle: ConfigDocument<Rectangle> | undefined;
             try {

--- a/src/common/rectangle/window.ts
+++ b/src/common/rectangle/window.ts
@@ -43,25 +43,27 @@ export const savedWindowsRectangle = async (rectangle: Rectangle) => {
 };
 const debounceSavedWindowsRectangle = debounce<t_savedWindowsRectangle>(savedWindowsRectangle, 500);
 
-export const getWindowPositionRectangle = async (winType?: AppWindowType): Promise<Rectangle> => {
+export const getWindowBounds = async (winType?: AppWindowType): Promise<Rectangle> => {
 
     try {
         const winRegistry = diMainGet("win-registry");
-        const appWindows = winRegistry.getAllWindows();
+        const readerWindows = winRegistry.getReaderWindows();
 
         const displayArea = screen.getPrimaryDisplay().workAreaSize;
 
         if (winType !== AppWindowType.Library && // is reader window
-            appWindows.length > 1) { // there are already reader windows
+            readerWindows.length > 0) { // there are already reader windows
 
-            const rectangle = appWindows[appWindows.length - 1].win.getBounds();
+            // readerWindows is ordered by creation/registration time
+            // so we take the latest reader window and offset the new one
+            const rectangle = readerWindows[readerWindows.length - 1].win.getBounds();
             rectangle.x += 100;
             rectangle.x %= displayArea.width - rectangle.width;
             rectangle.y += 100;
             rectangle.y %= displayArea.height - rectangle.height;
             return rectangle;
 
-        } else { // winType === AppWindowType.Library || appWindows.length == 1
+        } else { // winType === AppWindowType.Library || readerWindows.length == 0
 
             const configRepository: ConfigRepository<Rectangle> = diMainGet("config-repository");
             let rectangle: ConfigDocument<Rectangle> | undefined;

--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -9,7 +9,7 @@ import * as debug_ from "debug";
 import { app, BrowserWindow, Event, Menu, shell } from "electron";
 import * as path from "path";
 import { AppWindowType } from "readium-desktop/common/models/win";
-import { getWindowsRectangle } from "readium-desktop/common/rectangle/window";
+import { getWindowPositionRectangle } from "readium-desktop/common/rectangle/window";
 import { diMainGet } from "readium-desktop/main/di";
 import {
     _PACKAGING, _RENDERER_APP_BASE_URL, _VSCODE_LAUNCH, IS_DEV,
@@ -27,7 +27,7 @@ let mainWindow: BrowserWindow = null;
 // Opens the main window, with a native menu bar.
 export async function createWindow() {
     mainWindow = new BrowserWindow({
-        ...(await getWindowsRectangle()),
+        ...(await getWindowPositionRectangle()),
         minWidth: 800,
         minHeight: 600,
         webPreferences: {

--- a/src/main/createWindow.ts
+++ b/src/main/createWindow.ts
@@ -9,7 +9,7 @@ import * as debug_ from "debug";
 import { app, BrowserWindow, Event, Menu, shell } from "electron";
 import * as path from "path";
 import { AppWindowType } from "readium-desktop/common/models/win";
-import { getWindowPositionRectangle } from "readium-desktop/common/rectangle/window";
+import { getWindowBounds } from "readium-desktop/common/rectangle/window";
 import { diMainGet } from "readium-desktop/main/di";
 import {
     _PACKAGING, _RENDERER_APP_BASE_URL, _VSCODE_LAUNCH, IS_DEV,
@@ -27,7 +27,7 @@ let mainWindow: BrowserWindow = null;
 // Opens the main window, with a native menu bar.
 export async function createWindow() {
     mainWindow = new BrowserWindow({
-        ...(await getWindowPositionRectangle()),
+        ...(await getWindowBounds()),
         minWidth: 800,
         minHeight: 600,
         webPreferences: {

--- a/src/main/init.ts
+++ b/src/main/init.ts
@@ -145,7 +145,7 @@ const winCloseCallback = (appWindow: AppWindow) => {
             libraryWindow.win.close();
             return;
         }
-        libraryWindow.win.focus();
+        libraryWindow.win.show(); // focuses as well
     }
 };
 

--- a/src/main/init.ts
+++ b/src/main/init.ts
@@ -115,7 +115,7 @@ const winCloseCallback = (appWindow: AppWindow) => {
     const winRegistry = diMainGet("win-registry");
     const readerWindows = winRegistry.getReaderWindows();
 
-    // library window was close and unregistered
+    // library window was closed and unregistered
     // => all reader windows must now be closed too (effectively exiting the app)
     if (appWindow.type === AppWindowType.Library) {
         readerWindows.forEach((w) => w.win.close());

--- a/src/main/init.ts
+++ b/src/main/init.ts
@@ -8,9 +8,7 @@
 import * as debug_ from "debug";
 import { app, protocol } from "electron";
 import * as path from "path";
-import {
-    LocaleConfigIdentifier, LocaleConfigValueType,
-} from "readium-desktop/common/config";
+import { LocaleConfigIdentifier, LocaleConfigValueType } from "readium-desktop/common/config";
 import { syncIpc, winIpc } from "readium-desktop/common/ipc";
 import { ReaderMode } from "readium-desktop/common/models/reader";
 import { AppWindow, AppWindowType } from "readium-desktop/common/models/win";
@@ -22,6 +20,7 @@ import { AvailableLanguages } from "readium-desktop/common/services/translator";
 import { ConfigRepository } from "readium-desktop/main/db/repository/config";
 import { diMainGet } from "readium-desktop/main/di";
 import { appActions } from "readium-desktop/main/redux/actions/";
+import { ObjectKeys } from "readium-desktop/utils/object-keys-values";
 
 // Logger
 const debug = debug_("readium-desktop:main");
@@ -112,47 +111,41 @@ const winOpenCallback = (appWindow: AppWindow) => {
 // Callback called when a window is closed
 const winCloseCallback = (appWindow: AppWindow) => {
     const store = diMainGet("store");
+
     const winRegistry = diMainGet("win-registry");
+    const readerWindows = winRegistry.getReaderWindows();
 
-    // WinDictionary = BrowserWindows indexed by number
-    // (the number is Electron.BrowserWindow.id)
-    const windowsDict = winRegistry.getWindows();
+    // library window was close and unregistered
+    // => all reader windows must now be closed too (effectively exiting the app)
+    if (appWindow.type === AppWindowType.Library) {
+        readerWindows.forEach((w) => w.win.close());
+        return;
+    }
 
-    // generic / template type does not work because dictionary not indexed by string, but by number
-    // const windows = Object.values<AppWindow>(windowsDict);
-    const windows = Object.values(windowsDict) as AppWindow[];
+    // else: appWindow.type === AppWindowType.Reader
 
-    // dictionary not indexed by string, but by number!
-    // const browserWindowNumberIds = Object.keys(windowsDict) as unknown as number[];
+    // if there is at least one remaining reader, then leave it/them alone
+    // (it is / they are in detached mode, the library view is visible)
+    if (readerWindows.length > 0) {
+        return;
+    }
 
-    // if multiple windows are open & library are closed. all other windows are closed
-    if (windows.length >= 1 &&
-        appWindow.type === AppWindowType.Library) {
-        for (let i = windows.length - 1;
-            i >= 0; i--) {
-                windows[i].win.close();
+    // else, there is one window left, it is the library
+    // we ensure return to "attached" mode
+    store.dispatch(readerActions.detachModeSuccess.build(ReaderMode.Attached));
+
+    // if the library is in fact no visible
+    // (i.e. the sole closed reader was in attached mode)
+    // then we close the app
+    const libraryWindow = winRegistry.getLibraryWindow();
+    if (libraryWindow) {
+        if (libraryWindow.win.isMinimized()) {
+            libraryWindow.win.restore();
+        } else if (!libraryWindow.win.isVisible()) {
+            libraryWindow.win.close();
+            return;
         }
-        return;
-    }
-
-    if (windows.length !== 1) {
-        return;
-    }
-
-    const appWin = windows[0];
-    if (appWin.type === AppWindowType.Library) {
-        // Set reader to attached mode
-        store.dispatch(readerActions.detachModeSuccess.build(ReaderMode.Attached));
-    }
-
-    if (
-        appWin.type === AppWindowType.Library &&
-        !appWin.win.isVisible()
-    ) {
-        // Library window is hidden
-        // There is no more opened window
-        // Consider that we close application
-        appWin.win.close();
+        libraryWindow.win.focus();
     }
 };
 
@@ -172,7 +165,8 @@ export function initApp() {
         }
     }).catch(async () => {
         const loc = app.getLocale().split("-")[0];
-        const lang = Object.keys(AvailableLanguages).find((l) => l === loc) || "en";
+        const langCodes = ObjectKeys(AvailableLanguages);
+        const lang = langCodes.find((l) => l === loc) || "en";
         store.dispatch(i18nActions.setLocale.build(lang));
         debug(`create i18n key in configRepository with ${lang} locale`);
     });

--- a/src/main/lock.ts
+++ b/src/main/lock.ts
@@ -46,7 +46,7 @@ export function lockInstance() {
                 if (libraryAppWindow.win.isMinimized()) {
                     libraryAppWindow.win.restore();
                 }
-                libraryAppWindow.win.focus();
+                libraryAppWindow.win.show(); // focuses as well
             }
 
             // execute command line from second instance

--- a/src/main/lock.ts
+++ b/src/main/lock.ts
@@ -41,12 +41,12 @@ export function lockInstance() {
             debug("comandLine", argv, _workingDir);
 
             const winRegistry = diMainGet("win-registry");
-            const win = winRegistry.getWindow(1);
-            if (win && win.win) {
-                if (win.win.isMinimized()) {
-                    win.win.restore();
+            const libraryAppWindow = winRegistry.getLibraryWindow();
+            if (libraryAppWindow) {
+                if (libraryAppWindow.win.isMinimized()) {
+                    libraryAppWindow.win.restore();
                 }
-                win.win.focus();
+                libraryAppWindow.win.focus();
             }
 
             // execute command line from second instance

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -247,7 +247,10 @@ function* closeReader(reader: Reader, gotoLibrary: boolean) {
             yield call(async () => {
                 libraryAppWindow.win.setBounds(await getWindowBounds(AppWindowType.Library));
             });
-            libraryAppWindow.win.show();
+            if (libraryAppWindow.win.isMinimized()) {
+                libraryAppWindow.win.restore();
+            }
+            libraryAppWindow.win.show(); // focuses as well
         }
     }
 
@@ -360,13 +363,22 @@ export function* readerDetachRequestWatcher(): SagaIterator {
 
             const libraryAppWindow = winRegistry.getLibraryWindow();
             if (libraryAppWindow) {
-                libraryAppWindow.win.show();
+                // this should never occur, but let's do it for certainty
+                if (libraryAppWindow.win.isMinimized()) {
+                    libraryAppWindow.win.restore();
+                }
+                libraryAppWindow.win.show(); // focuses as well
             }
 
             const readerWindow = winRegistry.getWindowByIdentifier(reader.identifier);
             if (readerWindow) {
                 readerWindow.onWindowMoveResize.detach();
-                readerWindow.win.focus();
+
+                // this should never occur, but let's do it for certainty
+                if (readerWindow.win.isMinimized()) {
+                    readerWindow.win.restore();
+                }
+                readerWindow.win.show(); // focuses as well
             }
         }
 

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -11,8 +11,8 @@ import * as path from "path";
 import { LocatorType } from "readium-desktop/common/models/locator";
 import { Reader, ReaderConfig, ReaderMode } from "readium-desktop/common/models/reader";
 import { Timestampable } from "readium-desktop/common/models/timestampable";
-import { AppWindow, AppWindowType } from "readium-desktop/common/models/win";
-import { getWindowsRectangle } from "readium-desktop/common/rectangle/window";
+import { AppWindowType } from "readium-desktop/common/models/win";
+import { getWindowPositionRectangle } from "readium-desktop/common/rectangle/window";
 import { readerActions } from "readium-desktop/common/redux/actions";
 import { callTyped, selectTyped, takeTyped } from "readium-desktop/common/redux/typed-saga";
 import { ConfigDocument } from "readium-desktop/main/db/document/config";
@@ -38,7 +38,7 @@ async function openReader(publicationIdentifier: string, manifestUrl: string) {
     debug("create readerWindow");
     // Create reader window
     const readerWindow = new BrowserWindow({
-        ...(await getWindowsRectangle()),
+        ...(await getWindowPositionRectangle()),
         minWidth: 800,
         minHeight: 600,
         webPreferences: {
@@ -67,29 +67,29 @@ async function openReader(publicationIdentifier: string, manifestUrl: string) {
     }
 
     const winRegistry = diMainGet("win-registry");
+    const appWindows = winRegistry.getAllWindows();
 
-    // WinDictionary = BrowserWindows indexed by number
-    // (the number is Electron.BrowserWindow.id)
-    const windowsDict = winRegistry.getWindows();
+    const thereIsOnlyTheLibraryWindow = appWindows.length === 1;
 
-    // generic / template type does not work because dictionary not indexed by string, but by number
-    // const windows = Object.values<AppWindow>(windowsDict);
-    const windows = Object.values(windowsDict) as AppWindow[];
-
-    // If this is the only window, hide library window by default
-    if (windows.length === 1) {
-        const appWindow = windows[0];
-        appWindow.win.hide();
+    // Hide the only window (the library),
+    // as the new reader window will now take over
+    // (in other words: "detach" mode is disabled by default for new reader windows)
+    if (thereIsOnlyTheLibraryWindow) {
+        // Same as: appWindows[0]
+        const libraryAppWindow = winRegistry.getLibraryWindow();
+        if (libraryAppWindow) {
+            libraryAppWindow.win.hide();
+        }
     }
 
-    // Register reader window
     const readerAppWindow = winRegistry.registerWindow(
         readerWindow,
         AppWindowType.Reader,
         );
 
-    // If there are 2 win, record window position in the db
-    if (windows.length === 2) {
+    if (thereIsOnlyTheLibraryWindow) {
+        // onWindowMoveResize.detach() is called for reader windows that become ReaderMode.Detached
+        // (in which case the library window is shown again, and then its position takes precedence)
         readerAppWindow.onWindowMoveResize.attach();
     }
 
@@ -240,34 +240,19 @@ function* closeReader(reader: Reader, gotoLibrary: boolean) {
     }
 
     const winRegistry = diMainGet("win-registry");
-    const readerWindow = winRegistry.getWindowByIdentifier(reader.identifier);
 
     if (gotoLibrary) {
-        // Show library window
-
-        // WinDictionary = BrowserWindows indexed by number
-        // (the number is Electron.BrowserWindow.id)
-        const windowsDict = winRegistry.getWindows();
-
-        // generic / template type does not work because dictionary not indexed by string, but by number
-        // const windows = Object.values<AppWindow>(windowsDict);
-        const windows = Object.values(windowsDict) as AppWindow[];
-
-        for (const appWin of windows) {
-            if (appWin.type !== AppWindowType.Library) {
-                continue;
-            }
-            // update window rectangle position
+        const libraryAppWindow = winRegistry.getLibraryWindow();
+        if (libraryAppWindow) {
             yield call(async () => {
-                appWin.win.setBounds(await getWindowsRectangle(AppWindowType.Library));
+                libraryAppWindow.win.setBounds(await getWindowPositionRectangle(AppWindowType.Library));
             });
-
-            appWin.win.show();
+            libraryAppWindow.win.show();
         }
     }
 
-    // Close directly reader window
-    if (readerWindow && readerWindow.win) {
+    const readerWindow = winRegistry.getWindowByIdentifier(reader.identifier);
+    if (readerWindow) {
         readerWindow.win.close();
     }
 
@@ -353,10 +338,12 @@ export function* readerFullscreenRequestWatcher(): SagaIterator {
 
         // Get browser window
         const sender = action.sender;
+
         const winRegistry = diMainGet("win-registry");
         const appWindow = winRegistry.getWindowByIdentifier(sender.winId);
-        const browerWindow = appWindow.win as BrowserWindow;
-        browerWindow.setFullScreen(action.payload.full);
+        if (appWindow) {
+            appWindow.win.setFullScreen(action.payload.full);
+        }
     }
 }
 
@@ -370,25 +357,17 @@ export function* readerDetachRequestWatcher(): SagaIterator {
 
         if (readerMode === ReaderMode.Detached) {
             const winRegistry = diMainGet("win-registry");
-            const readerWindow = winRegistry.getWindowByIdentifier(reader.identifier);
 
-            // WinDictionary = BrowserWindows indexed by number
-            // (the number is Electron.BrowserWindow.id)
-            const windowsDict = winRegistry.getWindows();
-
-            // generic / template type does not work because dictionary not indexed by string, but by number
-            // const windows = Object.values<AppWindow>(windowsDict);
-            const windows = Object.values(windowsDict) as AppWindow[];
-
-            for (const appWin of windows) {
-                if (appWin.type !== AppWindowType.Library) {
-                    continue;
-                }
-
-                appWin.win.show();
+            const libraryAppWindow = winRegistry.getLibraryWindow();
+            if (libraryAppWindow) {
+                libraryAppWindow.win.show();
             }
-            readerWindow.onWindowMoveResize.detach();
-            readerWindow.win.focus();
+
+            const readerWindow = winRegistry.getWindowByIdentifier(reader.identifier);
+            if (readerWindow) {
+                readerWindow.onWindowMoveResize.detach();
+                readerWindow.win.focus();
+            }
         }
 
         yield put(readerActions.detachModeSuccess.build(readerMode));

--- a/src/main/redux/sagas/reader.ts
+++ b/src/main/redux/sagas/reader.ts
@@ -12,7 +12,7 @@ import { LocatorType } from "readium-desktop/common/models/locator";
 import { Reader, ReaderConfig, ReaderMode } from "readium-desktop/common/models/reader";
 import { Timestampable } from "readium-desktop/common/models/timestampable";
 import { AppWindowType } from "readium-desktop/common/models/win";
-import { getWindowPositionRectangle } from "readium-desktop/common/rectangle/window";
+import { getWindowBounds } from "readium-desktop/common/rectangle/window";
 import { readerActions } from "readium-desktop/common/redux/actions";
 import { callTyped, selectTyped, takeTyped } from "readium-desktop/common/redux/typed-saga";
 import { ConfigDocument } from "readium-desktop/main/db/document/config";
@@ -38,7 +38,7 @@ async function openReader(publicationIdentifier: string, manifestUrl: string) {
     debug("create readerWindow");
     // Create reader window
     const readerWindow = new BrowserWindow({
-        ...(await getWindowPositionRectangle()),
+        ...(await getWindowBounds()),
         minWidth: 800,
         minHeight: 600,
         webPreferences: {
@@ -245,7 +245,7 @@ function* closeReader(reader: Reader, gotoLibrary: boolean) {
         const libraryAppWindow = winRegistry.getLibraryWindow();
         if (libraryAppWindow) {
             yield call(async () => {
-                libraryAppWindow.win.setBounds(await getWindowPositionRectangle(AppWindowType.Library));
+                libraryAppWindow.win.setBounds(await getWindowBounds(AppWindowType.Library));
             });
             libraryAppWindow.win.show();
         }

--- a/src/main/services/catalog.ts
+++ b/src/main/services/catalog.ts
@@ -15,7 +15,6 @@ import { OPDSPublication } from "r2-opds-js/dist/es6-es2015/src/opds/opds2/opds2
 import { RandomCustomCovers } from "readium-desktop/common/models/custom-cover";
 import { Download } from "readium-desktop/common/models/download";
 import { ToastType } from "readium-desktop/common/models/toast";
-import { AppWindow } from "readium-desktop/common/models/win";
 import {
     downloadActions, readerActions, toastActions,
 } from "readium-desktop/common/redux/actions/";
@@ -237,25 +236,14 @@ export class CatalogService {
 
     public async exportPublication(publicationView: PublicationView) {
 
-        // WinDictionary = BrowserWindows indexed by number
-        // (the number is Electron.BrowserWindow.id)
-        const windowsDict = this.winRegistry.getWindows();
-
-        // generic / template type does not work because dictionary not indexed by string, but by number
-        // const windows = Object.values<AppWindow>(windowsDict);
-        const windows = Object.values(windowsDict) as AppWindow[];
-
-        let mainWindow: Electron.BrowserWindow;
-        for (const window of windows) {
-            if (window.type === "library") {
-                mainWindow = window.win;
-            }
-        }
+        const libraryAppWindow = this.winRegistry.getLibraryWindow();
 
         // Open a dialog to select a folder then copy the publication in it
-        const res = await dialog.showOpenDialog(mainWindow, {
-            properties: ["openDirectory"],
-        });
+        const res = await dialog.showOpenDialog(
+            libraryAppWindow ? libraryAppWindow.win : undefined,
+            {
+                properties: ["openDirectory"],
+            });
         if (!res.canceled) {
             if (res.filePaths && res.filePaths.length > 0) {
                 let destinationPath = res.filePaths[0];


### PR DESCRIPTION
clearer code for Window registry, removed confusion because of number indexing of mapped object (not an array), encapsulation was broken because of Electron BrowserWindow "id" internals exposed and assumption of ordered stack with explicit logic