### PR TITLE
[fix] rename CatalogService and fix hash calculation process

### DIFF
--- a/src/main/api/publication.ts
+++ b/src/main/api/publication.ts
@@ -14,8 +14,8 @@ import { PublicationViewConverter } from "readium-desktop/main/converter/publica
 import { PublicationDocument } from "readium-desktop/main/db/document/publication";
 import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
 import { diSymbolTable } from "readium-desktop/main/diSymbolTable";
-import { CatalogService } from "readium-desktop/main/services/catalog";
 import { LcpManager } from "readium-desktop/main/services/lcp";
+import { PublicationService } from "readium-desktop/main/services/publication";
 import { isArray } from "util";
 
 // import * as debug_ from "debug";
@@ -30,8 +30,8 @@ export class PublicationApi implements IPublicationApi {
     @inject(diSymbolTable["publication-view-converter"])
     private readonly publicationViewConverter!: PublicationViewConverter;
 
-    @inject(diSymbolTable["catalog-service"])
-    private readonly catalogService!: CatalogService;
+    @inject(diSymbolTable["publication-service"])
+    private readonly publicationService!: PublicationService;
 
     @inject(diSymbolTable["lcp-manager"])
     private readonly lcpManager!: LcpManager;
@@ -46,7 +46,7 @@ export class PublicationApi implements IPublicationApi {
     }
 
     public async delete(identifier: string): Promise<void> {
-        await this.catalogService.deletePublication(identifier);
+        await this.publicationService.deletePublication(identifier);
     }
 
     public async findAll(): Promise<PublicationView[]> {
@@ -93,7 +93,7 @@ export class PublicationApi implements IPublicationApi {
 
             let publicationDocument;
             try {
-                publicationDocument = await this.catalogService.importPublicationFromLink(
+                publicationDocument = await this.publicationService.importPublicationFromLink(
                     link,
                     r2OpdsPublicationBase64,
                 );
@@ -120,7 +120,7 @@ export class PublicationApi implements IPublicationApi {
         }
 
         const publicationDocumentPromises = filePathArray.map(
-            (filePath) => this.catalogService.importEpubOrLcplFile(filePath),
+            (filePath) => this.publicationService.importEpubOrLcplFile(filePath),
         );
         const publicationDocumentPromisesAll = await PromiseAllSettled(publicationDocumentPromises);
 
@@ -151,7 +151,7 @@ export class PublicationApi implements IPublicationApi {
 
     public async exportPublication(publicationView: PublicationView): Promise<void> {
         if (publicationView) {
-            await this.catalogService.exportPublication(publicationView);
+            await this.publicationService.exportPublication(publicationView);
         }
     }
 }

--- a/src/main/cli/commandLine.ts
+++ b/src/main/cli/commandLine.ts
@@ -42,7 +42,7 @@ export async function cliImport(filePath: string[] | string) {
     const filePathArray = isArray(filePath) ? filePath : [filePath];
 
     for (const fp of filePathArray) {
-        const catalogService = diMainGet("catalog-service");
+        const catalogService = diMainGet("publication-service");
         if (!await catalogService.importEpubOrLcplFile(fp)) {
             returnValue = false;
         }

--- a/src/main/di.ts
+++ b/src/main/di.ts
@@ -33,10 +33,10 @@ import { OpdsFeedRepository } from "readium-desktop/main/db/repository/opds";
 import { PublicationRepository } from "readium-desktop/main/db/repository/publication";
 import { diSymbolTable } from "readium-desktop/main/diSymbolTable";
 import { initStore } from "readium-desktop/main/redux/store/memory";
-import { CatalogService } from "readium-desktop/main/services/catalog";
 import { DeviceIdManager } from "readium-desktop/main/services/device";
 import { Downloader } from "readium-desktop/main/services/downloader";
 import { LcpManager } from "readium-desktop/main/services/lcp";
+import { PublicationService } from "readium-desktop/main/services/publication";
 import { WinRegistry } from "readium-desktop/main/services/win-registry";
 import { PublicationStorage } from "readium-desktop/main/storage/publication-storage";
 import { streamer } from "readium-desktop/main/streamer";
@@ -216,7 +216,7 @@ container.bind<DeviceIdManager>(diSymbolTable["device-id-manager"]).toConstantVa
 
 // Create lcp manager
 container.bind<LcpManager>(diSymbolTable["lcp-manager"]).to(LcpManager).inSingletonScope();
-container.bind<CatalogService>(diSymbolTable["catalog-service"]).to(CatalogService).inSingletonScope();
+container.bind<PublicationService>(diSymbolTable["publication-service"]).to(PublicationService).inSingletonScope();
 container.bind<OpdsService>(diSymbolTable["opds-service"]).to(OpdsService).inSingletonScope();
 
 // API
@@ -256,7 +256,7 @@ interface IGet {
     (s: "streamer"): Server;
     (s: "device-id-manager"): DeviceIdManager;
     (s: "lcp-manager"): LcpManager;
-    (s: "catalog-service"): CatalogService;
+    (s: "publication-service"): PublicationService;
     (s: "catalog-api"): CatalogApi;
     (s: "publication-api"): PublicationApi;
     (s: "opds-api"): OpdsApi;

--- a/src/main/diSymbolTable.ts
+++ b/src/main/diSymbolTable.ts
@@ -17,7 +17,7 @@ export const diSymbolTable = {
     "streamer": Symbol("streamer"),
     "device-id-manager": Symbol("device-id-manager"),
     "lcp-manager": Symbol("lcp-manager"),
-    "catalog-service": Symbol("catalog-service"),
+    "publication-service": Symbol("publication-service"),
     "opds-service": Symbol("opds-service"),
     "catalog-api": Symbol("catalog-api"),
     "publication-api": Symbol("publication-api"),

--- a/src/main/services/publication.ts
+++ b/src/main/services/publication.ts
@@ -50,7 +50,7 @@ import { WinRegistry } from "./win-registry";
 const debug = debug_("readium-desktop:main#services/catalog");
 
 @injectable()
-export class CatalogService {
+export class PublicationService {
     @inject(diSymbolTable["lcp-secret-repository"])
     private readonly lcpSecretRepository!: LcpSecretRepository;
 
@@ -85,26 +85,51 @@ export class CatalogService {
         const ext = path.extname(filePath);
         const isLCPLicense = ext === ".lcpl"; // || (ext === ".part" && isLcpFile);
         try {
+
             const hash = isLCPLicense ? undefined : await extractCrc32OnZip(filePath);
             const publicationArray = hash ? await this.publicationRepository.findByHashId(hash) : undefined;
-            if (publicationArray && publicationArray.length) {
+
+            if (publicationArray?.length) {
+
                 debug("importEpubOrLcplFile", publicationArray, hash);
                 publicationDocument = publicationArray[0];
-                this.store.dispatch(toastActions.openRequest.build(ToastType.Success,
-                    this.translator.translate("message.import.alreadyImport", { title: publicationDocument.title })));
+                this.store.dispatch(
+                    toastActions.openRequest.build(
+                        ToastType.Success,
+                        this.translator.translate(
+                            "message.import.alreadyImport", { title: publicationDocument.title },
+                        ),
+                    ),
+                );
             } else {
+
                 if (isLCPLicense) {
                     publicationDocument = await this.importLcplFile(filePath, lcpHashedPassphrase);
+
                 } else if (/\.epub[3]?$/.test(ext) || /\.audiobook$/.test(ext)) { //  || (ext === ".part" && !isLcpFile)
                     publicationDocument = await this.importEpubFile(filePath, hash, lcpHashedPassphrase);
+
                 }
-                this.store.dispatch(toastActions.openRequest.build(ToastType.Success,
-                    this.translator.translate("message.import.success", { title: publicationDocument.title })));
+                this.store.dispatch(
+                    toastActions.openRequest.build(
+                        ToastType.Success,
+                        this.translator.translate(
+                            "message.import.success", { title: publicationDocument.title },
+                        ),
+                    ),
+                );
             }
         } catch (error) {
+
             debug("importEpubOrLcplFile (hash + import) fail with :" + filePath, error);
-            this.store.dispatch(toastActions.openRequest.build(ToastType.Error,
-                this.translator.translate("message.import.fail", { path: filePath })));
+            this.store.dispatch(
+                toastActions.openRequest.build(
+                    ToastType.Error,
+                    this.translator.translate(
+                        "message.import.fail", { path: filePath },
+                    ),
+                ),
+            );
         }
         return publicationDocument;
     }
@@ -216,8 +241,14 @@ export class CatalogService {
                 },
             );
         } catch (err) {
-            this.store.dispatch(toastActions.openRequest.build(ToastType.Error,
-                this.translator.translate("message.download.error", { title, err: `[${err}]` })));
+            this.store.dispatch(
+                toastActions.openRequest.build(
+                    ToastType.Error,
+                    this.translator.translate(
+                        "message.download.error", { title, err: `[${err}]` },
+                    ),
+                ),
+            );
 
             this.store.dispatch(downloadActions.error.build(download.srcUrl));
             throw err;
@@ -329,7 +360,11 @@ export class CatalogService {
                 }
                 if (res) {
                     const msg = this.lcpManager.convertUnlockPublicationResultToString(res);
-                    this.store.dispatch(toastActions.openRequest.build(ToastType.Error, msg));
+                    this.store.dispatch(
+                        toastActions.openRequest.build(
+                            ToastType.Error, msg,
+                        ),
+                    );
                     throw new Error(`[${msg}] (${filePath})`);
                 }
             }
@@ -344,7 +379,11 @@ export class CatalogService {
                     // LICENSE_SIGNATURE_DATE_INVALID = 111
                     // LICENSE_SIGNATURE_INVALID = 112
                     const msg = this.lcpManager.convertUnlockPublicationResultToString(err);
-                    this.store.dispatch(toastActions.openRequest.build(ToastType.Error, msg));
+                    this.store.dispatch(
+                        toastActions.openRequest.build(
+                            ToastType.Error, msg,
+                        ),
+                    );
                     throw new Error(`[${msg}] (${filePath})`);
                 }
             }
@@ -413,15 +452,22 @@ export class CatalogService {
         await this.lcpManager.injectLcplIntoZip(download.dstPath, r2LCP);
         const hash = await extractCrc32OnZip(download.dstPath);
         const publicationArray = await this.publicationRepository.findByHashId(hash);
-        if (publicationArray && publicationArray.length) {
+        if (publicationArray?.length) {
+
             debug("importLcplFile", publicationArray, hash);
             const pubDocument = publicationArray[0];
-            this.store.dispatch(toastActions.openRequest.build(ToastType.Success,
-                this.translator.translate("message.import.alreadyImport", { title: pubDocument.title })));
+            this.store.dispatch(
+                toastActions.openRequest.build(
+                    ToastType.Success,
+                    this.translator.translate(
+                        "message.import.alreadyImport", { title: pubDocument.title },
+                    ),
+                ),
+            );
             return pubDocument;
         }
 
-        const publicationDocument = await this.importEpubFile(download.dstPath, undefined, lcpHashedPassphrase);
+        const publicationDocument = await this.importEpubFile(download.dstPath, hash, lcpHashedPassphrase);
         return publicationDocument;
         // return this.lcpManager.injectLcpl(publicationDocument, r2LCP);
     }
@@ -455,14 +501,14 @@ export class CatalogService {
             files: [],
             coverFile: null,
             customCover: null,
-            hash: hash ? hash : (hash === null ? undefined : await extractCrc32OnZip(filePath)),
+            hash: hash ? hash : await extractCrc32OnZip(filePath),
 
             lcp: null, // updated below via lcpManager.updateDocumentLcpLsdBase64Resources()
             lcpRightsCopies: 0,
         };
         this.lcpManager.updateDocumentLcpLsdBase64Resources(pubDocument, r2Publication.LCP);
 
-        debug(pubDocument.hash);
+        debug(`publication document ID=${pubDocument.identifier} HASH=${pubDocument.hash}`);
 
         // Store publication on filesystem
         debug("[START] Store publication on filesystem", filePath);


### PR DESCRIPTION
- renaming of CatalogService by PublicationService
- add the hash already generated as a parameter of the importEpubFile function to avoid a second computation
fixed from this commit (https://github.com/readium/readium-desktop/commit/312bb8b1eac30414a6618ba9115c62c8f9e37a9a)
